### PR TITLE
Release v1.3: fix SteamVR reload lifecycle

### DIFF
--- a/HitmanVRFoveationFix.ps1
+++ b/HitmanVRFoveationFix.ps1
@@ -1,5 +1,5 @@
 <#
-    HitmanVRFoveationFix  v1.2
+    HitmanVRFoveationFix  v1.3
     Edge-to-edge sharpness for HITMAN World of Assassination in PC VR.
 
     WHAT IT DOES
@@ -46,9 +46,10 @@
       launching through an OpenXR runtime lands on SteamVR anyway.
 
     WHAT IT TOUCHES
-      Nothing on disk. No game file is modified, nothing is written next to the
-      game. All changes are made in the memory of the running process and are
-      gone the moment you close HITMAN.
+      No game file or setting is modified. The tool writes a small
+      foveationfix.log next to itself for diagnostics. All renderer changes are
+      made in the memory of the running process and are gone the moment you
+      close HITMAN.
 
       It does write to the memory of a game that has an online connection. That
       is said plainly because you should know it. Use at your own discretion.
@@ -82,6 +83,21 @@ if (-not $me.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
 
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
+
+# Two instances can both observe stock code before either writes it, then each
+# believe it owns the patch. A named mutex closes that race before any game
+# handle is opened.
+$script:instanceMutex=New-Object Threading.Mutex($false,"Local\HitmanVRFoveationFix")
+$script:mutexOwned=$false
+try { $script:mutexOwned=$script:instanceMutex.WaitOne(0,$false) }
+catch [Threading.AbandonedMutexException] { $script:mutexOwned=$true }
+if (-not $script:mutexOwned) {
+    [Windows.Forms.MessageBox]::Show(
+        "HitmanVRFoveationFix is already running in this Windows session.",
+        "HitmanVRFoveationFix","OK","Information") | Out-Null
+    $script:instanceMutex.Dispose()
+    exit
+}
 
 if (-not ("HmFix" -as [type])) {
     Add-Type -TypeDefinition @'
@@ -233,35 +249,96 @@ function Find-Sig { param([byte[]]$hay,[string]$pat)
     return $hits }
 
 # --- state -----------------------------------------------------------------
-$script:handle=[IntPtr]::Zero; $script:gamePid=0; $script:base=0L
+$script:handle=[IntPtr]::Zero; $script:gamePid=0; $script:process=$null; $script:base=0L
 $script:mode=""            # verified | scanned
 $script:sites=@()
+$script:writtenSites=@()    # only sites this instance owns and may restore
 $script:devSlot=0L         # pattern path: RVA of the device pointer
 $script:wnoOff=$OFF_ACTIVE
 $script:patched=$false
-$script:dev=0L; $script:tex=0L; $script:valsOk=$false; $script:needRel=$false
+$script:dev=0L; $script:lastTrans=-1L; $script:needRel=$false
+$script:pendingValueWrite=$false
+$script:stableReady=0; $script:stableSince=0L
 $script:scaleStock=$null; $script:maskStock=$null
+$script:scaleTouched=$false; $script:maskTouched=$false
+$script:deviceRestoreUncertain=$false
+$script:runtimeLoaded=$false; $script:lastRuntimeCheck=0L
+$script:lastWriteLog=[DateTime]::MinValue; $script:lastUi=""
 $script:fatal=""; $script:stopped=$false
+
+function Reset-DeviceState { param([bool]$OwnershipBecameUncertain=$false)
+    if ($OwnershipBecameUncertain -and ($script:scaleTouched -or $script:maskTouched)) {
+        $script:deviceRestoreUncertain=$true }
+    $script:dev=0L; $script:lastTrans=-1L; $script:needRel=$false
+    $script:pendingValueWrite=$false
+    $script:stableReady=0; $script:stableSince=0L
+    $script:scaleStock=$null; $script:maskStock=$null
+    $script:scaleTouched=$false; $script:maskTouched=$false
+    $script:runtimeLoaded=$false; $script:lastRuntimeCheck=0L
+    $script:lastWriteLog=[DateTime]::MinValue }
+
+function Advance-Lifecycle {
+    param([Int64]$LastTransition,[bool]$NeedReload,[UInt32]$Transition,[bool]$ValuesWritten)
+    $changed=($LastTransition -ne [Int64]$Transition)
+    if ($Transition -ne 3) { $NeedReload=$false }
+    elseif ($ValuesWritten) { $NeedReload=$true }
+    return [pscustomobject]@{
+        LastTransition=[Int64]$Transition
+        NeedReload=$NeedReload
+        TransitionChanged=$changed
+        ResetStable=($changed -or $ValuesWritten) }
+}
 
 function Detach {
     if ($script:handle -ne [IntPtr]::Zero) { [HmFix]::CloseHandle($script:handle) | Out-Null }
-    $script:handle=[IntPtr]::Zero; $script:gamePid=0; $script:base=0L
-    $script:mode=""; $script:sites=@(); $script:devSlot=0L; $script:patched=$false
-    $script:dev=0L; $script:tex=0L; $script:valsOk=$false; $script:needRel=$false
-    $script:scaleStock=$null; $script:maskStock=$null }
+    $script:handle=[IntPtr]::Zero; $script:gamePid=0; $script:process=$null; $script:base=0L
+    $script:mode=""; $script:sites=@(); $script:writtenSites=@(); $script:devSlot=0L; $script:patched=$false
+    $script:dev=0L; $script:lastTrans=-1L; $script:needRel=$false
+    $script:pendingValueWrite=$false
+    $script:stableReady=0; $script:stableSince=0L
+    $script:scaleStock=$null; $script:maskStock=$null
+    $script:scaleTouched=$false; $script:maskTouched=$false
+    $script:deviceRestoreUncertain=$false
+    $script:runtimeLoaded=$false; $script:lastRuntimeCheck=0L
+    $script:lastWriteLog=[DateTime]::MinValue; $script:lastUi="" }
 
 function Restore {
-    if ($script:handle -eq [IntPtr]::Zero) { return }
-    try {
-        if ($script:valsOk -and $script:dev -ne 0) {
+    if ($script:handle -eq [IntPtr]::Zero) { return $true }
+    $ok=-not $script:deviceRestoreUncertain
+    if ($script:dev -ne 0) {
+        $deviceCurrent=$false
+        try { $deviceCurrent=((Get-Dev) -eq $script:dev) } catch {}
+        if (-not $deviceCurrent -and ($script:scaleTouched -or $script:maskTouched)) { $ok=$false }
+        if ($deviceCurrent -and $script:scaleTouched) {
             $sb = $script:scaleStock; if ($null -eq $sb) { $sb = W2B $SCALE_STOCK }
-            $mb = $script:maskStock;  if ($null -eq $mb) { $mb = $MASK_STOCK }
-            try { WB $script:handle ($script:dev+$OFF_SCALE) $sb } catch {}
-            try { WB $script:handle ($script:dev+$OFF_MASK)  $mb } catch {} }
-        if ($script:patched) {
-            foreach ($s in $script:sites) { try { WB $script:handle ($script:base+$s.RVA) $s.Stock } catch {} } }
-        Log "restored"
-    } catch {} }
+            try {
+                $cur=RB $script:handle ($script:dev+$OFF_SCALE) 16
+                if (Same $cur (W2B $SCALE_FIX)) {
+                    if ((Get-Dev) -ne $script:dev) { throw "device changed during restore" }
+                    WB $script:handle ($script:dev+$OFF_SCALE) $sb
+                    if (-not (Same (RB $script:handle ($script:dev+$OFF_SCALE) 16) $sb)) { $ok=$false } }
+                elseif (-not (Same $cur $sb)) { $ok=$false } }
+            catch { $ok=$false } }
+        if ($deviceCurrent -and $script:maskTouched) {
+            $mb = $script:maskStock; if ($null -eq $mb) { $mb = $MASK_STOCK }
+            try {
+                $cur=RB $script:handle ($script:dev+$OFF_MASK) 8
+                if (Same $cur $MASK_FIX) {
+                    if ((Get-Dev) -ne $script:dev) { throw "device changed during restore" }
+                    WB $script:handle ($script:dev+$OFF_MASK) $mb
+                    if (-not (Same (RB $script:handle ($script:dev+$OFF_MASK) 8) $mb)) { $ok=$false } }
+                elseif (-not (Same $cur $mb)) { $ok=$false } }
+            catch { $ok=$false } } }
+    foreach ($s in $script:writtenSites) {
+        try {
+            $cur=RB $script:handle ($script:base+$s.RVA) $s.Fix.Length
+            if (Same $cur $s.Fix) {
+                WB $script:handle ($script:base+$s.RVA) $s.Stock
+                if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Stock.Length) $s.Stock)) { $ok=$false } }
+            elseif (-not (Same $cur $s.Stock)) { $ok=$false } }
+        catch { $ok=$false } }
+    Log $(if($ok){"restored"}else{"restore incomplete - close HITMAN"})
+    return $ok }
 
 # --- window ----------------------------------------------------------------
 $form=New-Object Windows.Forms.Form
@@ -303,7 +380,7 @@ $steps=New-Object Windows.Forms.Label
 $steps.Location=New-Object Drawing.Point(22,214); $steps.Size=New-Object Drawing.Size(478,34)
 $steps.Font=New-Object Drawing.Font("Segoe UI",9)
 $steps.ForeColor=[Drawing.Color]::FromArgb(90,90,90)
-$steps.Text="Leave this window open while you play. Nothing is written to disk - closing HITMAN undoes everything."
+$steps.Text="Leave this window open while you play. No game file is changed - closing HITMAN undoes the renderer changes."
 $form.Controls.Add($steps)
 
 $btnStop=New-Object Windows.Forms.Button
@@ -313,13 +390,16 @@ $form.Controls.Add($btnStop)
 
 $link=New-Object Windows.Forms.LinkLabel
 $link.Location=New-Object Drawing.Point(240,260); $link.Size=New-Object Drawing.Size(260,22)
-$link.Text="v1.2 by RealChrizzl - project page"
+$link.Text="v1.3 by RealChrizzl - project page"
 $link.LinkArea=New-Object Windows.Forms.LinkArea(22,12)
 $link.TextAlign="MiddleRight"
 $link.Add_LinkClicked({ Start-Process "https://github.com/RealChrizzl/hitman-vr-foveation-fix" })
 $form.Controls.Add($link)
 
 function Show-State { param($colour,$head,$body,$warn="")
+    $uiKey=$colour+"`n"+$head+"`n"+$body+"`n"+$warn
+    if ($script:lastUi -eq $uiKey) { return }
+    $script:lastUi=$uiKey
     $dot.ForeColor = switch ($colour) {
         "green" { [Drawing.Color]::FromArgb(0,150,60) }
         "amber" { [Drawing.Color]::FromArgb(220,140,0) }
@@ -355,7 +435,9 @@ function Try-Attach {
             if ($h.Count -ne 1) {
                 $script:fatal="The code for '" + $s.What + "' could not be located uniquely in this build. Nothing was changed. Please report this build on the project page."
                 return $false }
-            $sites += [pscustomobject]@{ RVA=[int64]($pe2.TextRVA+$h[0]+$s.Hit); Stock=$null; Fix=$s.Fix } }
+            $stock=New-Object byte[] $s.Fix.Length
+            [Array]::Copy($pe2.Text,$h[0]+$s.Hit,$stock,0,$stock.Length)
+            $sites += [pscustomobject]@{ RVA=[int64]($pe2.TextRVA+$h[0]+$s.Hit); Stock=$stock; Fix=$s.Fix } }
         $h=@(Find-Sig $pe2.Text $SIG_DEVICE_PAT)
         if ($h.Count -ne 1) { $script:fatal="The VR device reference could not be located uniquely in this build. Nothing was changed."; return $false }
         $at=$h[0]
@@ -368,7 +450,7 @@ function Try-Attach {
     $hnd=[HmFix]::OpenProcess(0x1F0FFF,$false,$p.Id)
     if ($hnd -eq [IntPtr]::Zero) { $script:fatal="Access denied. Close this tool and start it as administrator."; return $false }
 
-    $script:handle=$hnd; $script:gamePid=$p.Id; $script:base=$b
+    $script:handle=$hnd; $script:gamePid=$p.Id; $script:process=$p; $script:base=$b
     $script:mode=$mode; $script:sites=$sites; $script:devSlot=$slot; $script:wnoOff=$wno
     Log ("attached pid {0}, build {1}, mode {2}" -f $p.Id,$stamp,$mode)
     return $true }
@@ -410,22 +492,114 @@ function VR-Running {
 
 # Either backend is fine - the device layout is identical, verified on both.
 function VR-Runtime-Loaded {
-    try { foreach ($m in (Get-Process -Id $script:gamePid).Modules) {
+    try {
+        # Process.Modules is cached by System.Diagnostics.Process. Refresh is
+        # required or a runtime loaded after the first check is never observed.
+        $script:process.Refresh()
+        foreach ($m in $script:process.Modules) {
             if ($m.ModuleName -like "LibOVRRT*" -or $m.ModuleName -like "openvr_api*") { return $true } } } catch {}
     return $false }
 
-function Apply-Code {
-    # pattern path: take the original bytes straight from the process
-    foreach ($s in $script:sites) {
-        if ($null -eq $s.Stock) {
-            $s.Stock = RB $script:handle ($script:base+$s.RVA) $s.Fix.Length } }
+# Read and neutralise the device values as soon as its geometry block is valid.
+# In particular this runs before +0x319 becomes active.  OpenVR rebuilds the
+# shader/constant-buffer state during mission and save-game loads; changing these
+# fields only after that rebuild leaves the old centre mask cached on the GPU.
+function Sync-RenderValues { param([Int64]$d)
+    $result=[pscustomobject]@{ Initialized=$false; Fixed=$false; Wrote=$false; Error="" }
 
+    $fb=RB $script:handle ($d+$OFF_FOV) 16
+    for ($i=0;$i -lt 4;$i++) {
+        $f=[BitConverter]::ToSingle($fb,$i*4)
+        if ([Single]::IsNaN($f) -or [Single]::IsInfinity($f) -or $f -lt 0.2 -or $f -gt 3.0) {
+            return $result } }
+
+    $sb=RB $script:handle ($d+$OFF_SCALE) 16
+    for ($i=0;$i -lt 4;$i++) {
+        $f=[BitConverter]::ToSingle($sb,$i*4)
+        # All-zero scale fields mean the device builder has not reached this
+        # block yet.  Do not capture or overwrite partially constructed data.
+        if ([Single]::IsNaN($f) -or [Single]::IsInfinity($f) -or $f -lt 0.05 -or $f -gt 20.0) {
+            return $result } }
+
+    $mb=RB $script:handle ($d+$OFF_MASK) 8
+    for ($i=0;$i -lt 2;$i++) {
+        $f=[BitConverter]::ToSingle($mb,$i*4)
+        if ([Single]::IsNaN($f) -or [Single]::IsInfinity($f) -or $f -lt -0.01 -or $f -gt 4.0) {
+            return $result } }
+
+    $result.Initialized=$true
+    $scaleFixBytes=W2B $SCALE_FIX
+    $sOk=Same $sb $scaleFixBytes
+    $mOk=Same $mb $MASK_FIX
+
+    if (-not $sOk) {
+        $wasTouched=$script:scaleTouched
+        if (-not $wasTouched) { $script:scaleStock=$sb }
+        # Claim ownership before the call. WriteProcessMemory may modify a prefix
+        # (or even all bytes) and still report failure/a short write.
+        $script:scaleTouched=$true; $result.Wrote=$true
+        try { WB $script:handle ($d+$OFF_SCALE) $scaleFixBytes } catch {}
+        try { $after=RB $script:handle ($d+$OFF_SCALE) 16 }
+        catch {
+            $script:deviceRestoreUncertain=$true
+            $result.Error="Scale write could not be verified. Close HITMAN if this repeats."
+            return $result }
+        if (-not (Same $after $scaleFixBytes)) {
+            $rolledBack=Same $after $sb
+            if (-not $rolledBack) {
+                try {
+                    WB $script:handle ($d+$OFF_SCALE) $sb
+                    $rolledBack=Same (RB $script:handle ($d+$OFF_SCALE) 16) $sb }
+                catch { $rolledBack=$false } }
+            if ($rolledBack -and -not $wasTouched) {
+                $script:scaleTouched=$false; $script:scaleStock=$null }
+            if (-not $rolledBack) { $script:deviceRestoreUncertain=$true }
+            $result.Error=if($rolledBack){"Scale write failed and was rolled back; retrying."}else{"Scale write left an unknown value. Close HITMAN."}
+            return $result } }
+    if (-not $mOk) {
+        $wasTouched=$script:maskTouched
+        if (-not $wasTouched) { $script:maskStock=$mb }
+        $script:maskTouched=$true; $result.Wrote=$true
+        try { WB $script:handle ($d+$OFF_MASK) $MASK_FIX } catch {}
+        try { $after=RB $script:handle ($d+$OFF_MASK) 8 }
+        catch {
+            $script:deviceRestoreUncertain=$true
+            $result.Error="Mask write could not be verified. Close HITMAN if this repeats."
+            return $result }
+        if (-not (Same $after $MASK_FIX)) {
+            $rolledBack=Same $after $mb
+            if (-not $rolledBack) {
+                try {
+                    WB $script:handle ($d+$OFF_MASK) $mb
+                    $rolledBack=Same (RB $script:handle ($d+$OFF_MASK) 8) $mb }
+                catch { $rolledBack=$false } }
+            if ($rolledBack -and -not $wasTouched) {
+                $script:maskTouched=$false; $script:maskStock=$null }
+            if (-not $rolledBack) { $script:deviceRestoreUncertain=$true }
+            $result.Error=if($rolledBack){"Mask write failed and was rolled back; retrying."}else{"Mask write left an unknown value. Close HITMAN."}
+            return $result } }
+
+    # A failed or immediately overwritten value must not result in a green
+    # status.  A later tick retries it during the same loading transition.
+    try {
+        $result.Fixed = (Same (RB $script:handle ($d+$OFF_SCALE) 16) $scaleFixBytes) -and
+                        (Same (RB $script:handle ($d+$OFF_MASK) 8) $MASK_FIX) }
+    catch {
+        # Preserve Wrote=true so a write made after transition 3 still latches
+        # the required reload even when this final verification read is lost.
+        $result.Error="Render values were written but the final verification read failed; retrying."
+        return $result }
+    return $result }
+
+function Apply-Code {
     $allFix=$true; $allStock=$true
     foreach ($s in $script:sites) {
         $cur = RB $script:handle ($script:base+$s.RVA) $s.Fix.Length
         if (-not (Same $cur $s.Fix))   { $allFix=$false }
         if (-not (Same $cur $s.Stock)) { $allStock=$false } }
-    if ($allFix) { $script:patched=$true; return $true }
+    if ($allFix) {
+        $script:fatal="HITMAN was already patched before this tool attached. Close every fix window and HITMAN, then start this tool again."
+        return $false }
     if (-not $allStock) {
         $script:fatal="The game code is not in its original state. Close HITMAN, start it again, then this tool."
         return $false }
@@ -434,25 +608,51 @@ function Apply-Code {
         $script:fatal="VR was already running when this tool attached. Close HITMAN, start this tool first, then the game."
         return $false }
 
-    foreach ($s in $script:sites) { WB $script:handle ($script:base+$s.RVA) $s.Fix }
-    Start-Sleep -Milliseconds 60
-    foreach ($s in $script:sites) {
-        if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Fix.Length) $s.Fix)) {
-            $script:fatal="A patch did not stick. Please restart HITMAN."; return $false } }
+    $written=@()
+    try {
+        foreach ($s in $script:sites) {
+            # Include the site before attempting the write: WriteProcessMemory
+            # can modify a prefix and still report a short/failed write.
+            $written += $s
+            WB $script:handle ($script:base+$s.RVA) $s.Fix }
+        Start-Sleep -Milliseconds 60
+        foreach ($s in $script:sites) {
+            if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Fix.Length) $s.Fix)) {
+                throw "verification failed" } }
+    } catch {
+        # Never leave the game with only a subset of the five instructions
+        # patched.  Roll back every site written by this attempt immediately.
+        $rollbackOk=$true
+        foreach ($s in $written) {
+            try {
+                WB $script:handle ($script:base+$s.RVA) $s.Stock
+                if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Stock.Length) $s.Stock)) {
+                    $rollbackOk=$false } }
+            catch { $rollbackOk=$false } }
+        $script:writtenSites=@()
+        if ($rollbackOk) {
+            $script:fatal="A patch did not stick. The partial change was rolled back; please restart HITMAN." }
+        else {
+            $script:fatal="A patch failed and could not be rolled back safely. Close HITMAN now; all changes disappear when the game exits." }
+        return $false }
+    $script:writtenSites=$written
     $script:patched=$true; Log "code patched"
     return $true }
 
 # --- main loop -------------------------------------------------------------
 $timer=New-Object Windows.Forms.Timer
-$timer.Interval=250
+$timer.Interval=15
 $timer.Add_Tick({
     try {
         if ($script:stopped) { return }
 
-        if ($script:handle -ne [IntPtr]::Zero -and -not (Get-Process -Id $script:gamePid -ErrorAction SilentlyContinue)) {
-            Log "game closed"; Detach; $script:fatal=""
-            Show-State "grey" "Waiting for HITMAN" "The game was closed. Start it again and this tool will patch it once more."
-            $btnStop.Enabled=$false; return }
+        if ($script:handle -ne [IntPtr]::Zero) {
+            $gameClosed=$false
+            try { $gameClosed=($null -eq $script:process -or $script:process.HasExited) } catch { $gameClosed=$true }
+            if ($gameClosed) {
+                Log "game closed"; Detach; $script:fatal=""
+                Show-State "grey" "Waiting for HITMAN" "The game was closed. Start it again and this tool will patch it once more."
+                $btnStop.Enabled=$false; return } }
 
         if ($script:fatal) { Show-State "red" "Not active" $script:fatal; return }
 
@@ -472,10 +672,18 @@ $timer.Add_Tick({
 
         $d = Get-Dev
         if ($d -eq -1L) {
+            if ($script:dev -ne 0) { Reset-DeviceState $true }
             Show-State "red" "Unsupported backend" "The active VR device is neither the Oculus nor the SteamVR one this tool was verified against."
             return }
-        if ($d -eq 0L) { Show-State "amber" "Ready - start VR" $ready $warn; return }
-        $script:dev=$d
+        if ($d -eq 0L) {
+            if ($script:dev -ne 0) {
+                Log "VR device became unavailable"
+                Reset-DeviceState $true }
+            Show-State "amber" "Ready - start VR" $ready $warn; return }
+        if ($d -ne $script:dev) {
+            if ($script:dev -ne 0) { Reset-DeviceState $true } else { Reset-DeviceState }
+            $script:dev=$d
+            Log ("VR device found at 0x{0:X}" -f $d) }
 
         $active=U8  $script:handle ($d+$OFF_ACTIVE)
         $wno   =U8  $script:handle ($d+$script:wnoOff)
@@ -485,65 +693,111 @@ $timer.Add_Tick({
         $w     =U32 $script:handle ($d+$OFF_W)
         $h     =U32 $script:handle ($d+$OFF_H)
 
-        if ($active -ne 1) { Show-State "amber" "Ready - start VR" $ready $warn; return }
-        if ($script:mode -eq "scanned" -and -not (VR-Runtime-Loaded)) {
-            Show-State "red" "No VR runtime" "Neither the Oculus nor the SteamVR runtime is loaded in the game."
+        if ($script:mode -eq "scanned" -and -not $script:runtimeLoaded) {
+            $runtimeNow=[Diagnostics.Stopwatch]::GetTimestamp()
+            $runtimeAge=if($script:lastRuntimeCheck -eq 0){[double]::PositiveInfinity}else{($runtimeNow-$script:lastRuntimeCheck)*1000.0/[Diagnostics.Stopwatch]::Frequency}
+            if ($runtimeAge -ge 500) {
+                $script:runtimeLoaded=VR-Runtime-Loaded
+                $script:lastRuntimeCheck=$runtimeNow }
+        }
+        if ($script:mode -eq "scanned" -and -not $script:runtimeLoaded) {
+            $script:stableReady=0; $script:stableSince=0L
+            $script:lastTrans=-1L; $script:needRel=$false
+            if ($active -eq 1) {
+                Show-State "red" "No VR runtime" "Neither the Oculus nor the SteamVR runtime is loaded in the game." }
+            else { Show-State "amber" "Ready - start VR" $ready $warn }
             return }
-        if ($wno -ne 0) {
+
+        if ($active -eq 1 -and $wno -ne 0) {
+            $script:stableReady=0; $script:stableSince=0L
             Show-State "red" "Not active" "VR started before the patch could take effect. Close HITMAN, start this tool first, then the game."
             return }
 
-        if ($tex -ne $script:tex) { $script:tex=$tex; $script:needRel=$false; $script:valsOk=$false }
+        $sync=Sync-RenderValues $d
+        if ($sync.Wrote) {
+            $script:pendingValueWrite=$true
+            # Close the read/write race: classify the write using a fresh state
+            # sample. The renderer may have reached transition 3 while the two
+            # value groups were being written.
+            $active=U8  $script:handle ($d+$OFF_ACTIVE)
+            $wno   =U8  $script:handle ($d+$script:wnoOff)
+            $trans =U32 $script:handle ($d+$OFF_TRANS)
+            $layers=U16 $script:handle ($d+$OFF_LAYERS)
+            $tex   =I64 $script:handle ($d+$OFF_TEX)
+            $w     =U32 $script:handle ($d+$OFF_W)
+            $h     =U32 $script:handle ($d+$OFF_H) }
 
-        # The two backends report slightly different numbers here, so this is a
-        # plausibility check rather than an exact match: four tangent values that
-        # must sit in a sane range. Wrong layout fails it, a different headset
-        # does not.
-        $fovOk=$false
-        try {
-            $fb = RB $script:handle ($d+$OFF_FOV) 16
-            $fovOk=$true
-            for ($i=0;$i -lt 4;$i++) {
-                $f=[BitConverter]::ToSingle($fb,$i*4)
-                if ($f -lt 0.2 -or $f -gt 3.0) { $fovOk=$false } }
-        } catch {}
+        if ($active -eq 1 -and $wno -ne 0) {
+            $script:stableReady=0; $script:stableSince=0L
+            Show-State "red" "Not active" "VR started before the patch could take effect. Close HITMAN, start this tool first, then the game."
+            return }
 
-        if ($fovOk) {
-            $sOk = Same (RB $script:handle ($d+$OFF_SCALE) 16) (W2B $SCALE_FIX)
-            $mOk = Same (RB $script:handle ($d+$OFF_MASK) 8) $MASK_FIX
-            if (-not ($sOk -and $mOk)) {
-                # remember what was actually there before touching it
-                if ($null -eq $script:scaleStock) {
-                    try { $script:scaleStock = RB $script:handle ($d+$OFF_SCALE) 16 } catch {}
-                    try { $script:maskStock  = RB $script:handle ($d+$OFF_MASK) 8 }  catch {} }
-                WB $script:handle ($d+$OFF_SCALE) (W2B $SCALE_FIX)
-                WB $script:handle ($d+$OFF_MASK)  $MASK_FIX
-                if ($trans -eq 3) { $script:needRel=$true }
-                $script:valsOk=$true
-                Log ("values written, transition=" + $trans) } }
+        $life=Advance-Lifecycle $script:lastTrans $script:needRel $trans $script:pendingValueWrite
+        if ($life.TransitionChanged) {
+            Log ("transition {0} -> {1}" -f $script:lastTrans,$trans) }
+        $script:lastTrans=$life.LastTransition
+        $script:needRel=$life.NeedReload
+        $script:pendingValueWrite=$false
+        if ($life.ResetStable) { $script:stableReady=0; $script:stableSince=0L }
+
+        if ($sync.Wrote) {
+            $now=Get-Date
+            if (($now-$script:lastWriteLog).TotalSeconds -ge 1) {
+                Log ("values synchronised, transition={0}, active={1}" -f $trans,$active)
+                $script:lastWriteLog=$now } }
+
+        if ($sync.Error) {
+            $script:stableReady=0; $script:stableSince=0L
+            Show-State "red" "Renderer write failed" $sync.Error $warn
+            return }
+
+        if ($active -ne 1) {
+            $script:stableReady=0; $script:stableSince=0L
+            Show-State "amber" "Ready - start VR" $ready $warn; return }
+
+        if (-not $sync.Initialized -or -not $sync.Fixed) {
+            $script:stableReady=0; $script:stableSince=0L
+            Show-State "amber" "Waiting for the VR renderer" "The device is still initialising. The fix will arm before its render state is built." $warn
+            return }
 
         if ($trans -ne 3 -or $layers -ne 2 -or $tex -eq 0) {
+            $script:stableReady=0; $script:stableSince=0L
             Show-State "amber" "Waiting for a mission" "VR is running in two-layer mode. Load a mission and the fix becomes active." $warn
             return }
 
         if ($script:needRel) {
+            $script:stableReady=0; $script:stableSince=0L
             Show-State "amber" "Reload this mission once" "The fix is set, but this mission was already running when it was applied. Reload it once and the image will be sharp everywhere." $warn
         } else {
-            Show-State "green" "Active" ("Sharp from edge to edge. Rendering {0} x {1} per eye in two layers instead of four." -f $w,$h) $warn }
+            $stableNow=[Diagnostics.Stopwatch]::GetTimestamp()
+            if ($script:stableSince -eq 0) { $script:stableSince=$stableNow }
+            if ($script:stableReady -lt 3) { $script:stableReady++ }
+            $stableMs=($stableNow-$script:stableSince)*1000.0/[Diagnostics.Stopwatch]::Frequency
+            if ($script:stableReady -lt 3 -or $stableMs -lt 250) {
+                Show-State "amber" "Finishing the mission load" "The render values are correct. Waiting briefly to make sure they remain stable." $warn
+            } else {
+                Show-State "green" "Active" ("Sharp from edge to edge. Rendering {0} x {1} per eye in two layers instead of four." -f $w,$h) $warn } }
     } catch {
         Show-State "red" "Something went wrong" ($_.Exception.Message + "  Close HITMAN and try again.") }
 })
 $timer.Start()
 
 $btnStop.Add_Click({
-    Restore; Detach
+    $restored=Restore; Detach
     $script:stopped=$true; $script:fatal=""
     $btnStop.Enabled=$false
-    Show-State "grey" "Turned off" "Everything was restored. Close and reopen this tool to use the fix again." })
+    if ($restored) {
+        Show-State "grey" "Turned off" "Everything this tool changed was restored. Close and reopen it to use the fix again." }
+    else {
+        Show-State "amber" "Close HITMAN" "A live value could not be restored safely. Closing the game always discards every in-memory change." } })
 
 $form.Add_FormClosing({
-    $timer.Stop(); Restore
+    $timer.Stop(); Restore | Out-Null
     if ($script:handle -ne [IntPtr]::Zero) { [HmFix]::CloseHandle($script:handle) | Out-Null }
+    if ($script:mutexOwned) {
+        try { $script:instanceMutex.ReleaseMutex() } catch {}
+        $script:mutexOwned=$false }
+    try { $script:instanceMutex.Dispose() } catch {}
     Log "closed" })
 
 [void]$form.ShowDialog()

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ only thing left blurring the picture. On Fresnel headsets (Quest 2, Quest 3S, Ri
 it works too, the gain is just smaller because the lenses already soften the
 periphery.
 
-PC VR only, not the standalone version. Both of the game's VR backends work:
-**Oculus** (Quest via Link or Air Link, Rift S) and **SteamVR** (anything on
-OpenVR, including Quest headsets over Steam Link or Virtual Desktop, and Vive,
-Index, Bigscreen Beyond and friends).
+PC VR only, not the standalone version. Both of the game's VR backends are supported
+and verified: **Oculus** (Quest via Link or Air Link, Rift S) and **SteamVR / OpenVR**
+(including headsets connected through Steam Link, Virtual Desktop or their native
+PC streaming software).
 
 ---
 
@@ -41,6 +41,10 @@ pictograms on the bins. Same scene, same settings, same headset.
 4. Play
 
 That is the whole procedure. Leave the small window open while you play.
+
+> **SteamVR / OpenVR:** v1.3 replaces the timing-sensitive v1.2 reload logic and has
+> been visually verified in the headset across new missions, mission restarts,
+> save-game loads, scene changes and Freelancer mode.
 
 The window tells you what is going on: grey while it waits for the game, amber while
 VR or a mission is still loading, **green when the fix is active**. If something is
@@ -94,13 +98,16 @@ No resolution setting is changed. You do not need to raise anything.
 
 ## Is it safe
 
-- **Nothing is written to disk.** No game file is modified, nothing is installed,
-  nothing is left behind. Every change is made in the memory of the running process
-  and disappears the moment you close HITMAN.
+- **No game file or setting is modified.** Renderer changes are made in the memory
+  of the running process and disappear when you close HITMAN. The tool keeps a small
+  `foveationfix.log` beside the script so timing problems can be diagnosed; it contains
+  timestamps and renderer state changes and can be deleted at any time.
 - It refuses to do anything if the game code is not in its original state, if VR is
   already running when it attaches, or if the VR device does not look the way it
   expects.
-- Turning it off or closing the window restores everything.
+- Turning it off or closing the window restores the bytes owned by that tool
+  instance when they are still safe to touch. Closing HITMAN itself always discards
+  every in-memory change.
 
 **Said plainly:** it does write to the memory of a game that has an online connection.
 That has been fine in testing, but you should know it before you decide. There is no
@@ -135,7 +142,8 @@ something different, and the message alone usually identifies the cause.
 For anything beyond that there is a read-only diagnostic in
 [`tools/`](tools/). Put `HitmanVRProbe.ps1` and `HitmanVRProbe.bat` in the same
 folder, start the game, get into VR and into a mission, double-click the `.bat` and
-press **Copy report**.
+press **Copy report**. Probe v1.1 also reports whether every live code site is
+stock, fixed, or unexpected; a foveation value of zero is now displayed correctly.
 
 It imports only `OpenProcess`, `ReadProcessMemory` and `CloseHandle` — no write
 function is declared at all, so it cannot modify the game even in principle.

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -71,13 +71,27 @@ else — the device layout, the field offsets, the other three patches — is sh
 between them, which was confirmed by comparing probe reports from both runtimes on
 the same machine.
 
-### Once a mission is loaded
+### While VR and a mission initialise
 
 | Field | Value | Effect |
 |---|---|---|
 | `device+0x490 … +0x49C` | `1.0` ×4 | small/large scale ratios neutralised |
 | `device+0x4C0` | `0` | overlay pass off — removes the ghost images |
 | `device+0x4C4` | `0` | removes the black circle in the centre |
+
+OpenVR rebuilds the render state during mission, scene, and save-game loads. These
+fields must therefore be neutralised before that state reaches transition 3, not
+merely after a new texture pointer appears. v1.3 watches the transition at 15 ms,
+writes as soon as the device geometry is plausible (including before `active=1`),
+reads the values back, and requires multiple samples plus a 250 ms monotonic stable
+window before showing green. A write first observed after transition 3 remains amber
+and asks for one real reload.
+
+This lifecycle has been visually verified in the headset across new missions,
+mission restarts, save-game loads, scene changes and Freelancer mode. Polling is
+still not the same as synchronising with the render thread; if a future game build
+reintroduces a fast-load race, the next step is to re-derive and patch the scale/mask
+producer or constant-buffer builder from that build's binary.
 
 Stock values for reference: `+0x490…` = `3EDF2BF0 3ECE8B44 4012D426 401EA625`,
 `+0x4C0/+0x4C4` = `3D 2D 66 3F  DA B9 4D 3E`.

--- a/docs/RELEASE-NOTES-1.3.md
+++ b/docs/RELEASE-NOTES-1.3.md
@@ -1,0 +1,64 @@
+# HitmanVRFoveationFix v1.3
+
+Version 1.3 fixes the timing-sensitive SteamVR / OpenVR loading behavior that could
+leave a bright image, black circles in the center of the view, or make the fix work
+only on some game starts.
+
+This release addresses the SteamVR / OpenVR reports in #1, #2, #3 and #4.
+
+## Highlights
+
+- Fixed SteamVR / OpenVR initialization, mission reload and save-game loading.
+- Fixed intermittent black circles and overbright rendering caused by stale render
+  state.
+- Render values are now neutralized as soon as the VR device geometry is ready,
+  including before the device becomes active.
+- Mission generations are tracked through renderer transitions instead of texture
+  pointer changes, which also covers pointer reuse.
+- The renderer is checked every 15 ms during initialization and must remain correct
+  for a 250 ms stability window before the tool reports **Active**.
+- A write that occurs too late is remembered reliably and the tool requests one real
+  mission reload instead of showing a false green status.
+- Device recreation, transient read failures and partial writes are handled safely.
+- Code patching is transactional: incomplete patches are rolled back immediately.
+- Restore only touches bytes owned by the current tool instance and refuses unsafe
+  restoration when the game state has changed underneath it.
+- A named mutex prevents two fix windows from modifying the same game process.
+
+## Probe 1.1
+
+- Fixed zero-valued fields being reported as `unreadable`; a foveation flag of `0`
+  is now displayed correctly.
+- Added live status for every code patch site: `stock`, `fixed`, `other` or
+  `unreadable`.
+- Added the SteamVR / OpenVR field-of-view patch site.
+- Clarified that the probe never writes to HITMAN; Copy and Save only affect the
+  generated report.
+
+## Verified scenarios
+
+The v1.3 lifecycle fix has been visually tested in the headset with:
+
+- a newly loaded mission;
+- a mission restart;
+- loading a save game;
+- changing scenes; and
+- Freelancer mode.
+
+The existing Oculus / LibOVR path remains supported. The SteamVR / OpenVR device
+layout and live rendering behavior are verified on HITMAN World of Assassination
+build 3.270.1.
+
+## Updating from v1.2
+
+1. Close HITMAN and every older HitmanVRFoveationFix window.
+2. Replace the old files with the contents of the v1.3 ZIP.
+3. Start `HitmanVRFoveationFix.bat` before starting HITMAN.
+4. Leave the fix window open while playing.
+
+The tool does not modify game files or settings. Renderer changes remain in the
+running process and disappear when HITMAN closes. Version 1.3 writes a small
+`foveationfix.log` beside the script for diagnostics.
+
+If a problem returns after a future game update, attach that log and a fresh report
+from `tools/HitmanVRProbe.bat` to a GitHub issue.

--- a/tools/HitmanVRProbe.ps1
+++ b/tools/HitmanVRProbe.ps1
@@ -1,20 +1,18 @@
 <#
-    HitmanVRProbe  v1.0
+    HitmanVRProbe  v1.1
     Read-only diagnostic for HitmanVRFoveationFix.
 
     WHAT THIS IS FOR
-      HitmanVRFoveationFix currently only supports the Oculus / LibOVR backend.
-      To add SteamVR / OpenVR support I need to know whether the OpenVR device
-      object in HITMAN has the same internal layout as the Oculus one.
+      This tool verifies the live patch bytes and reads the renderer lifecycle
+      values needed to diagnose Oculus and SteamVR / OpenVR problems. It prints a
+      report you can paste into a GitHub issue.
 
-      This tool finds out. It reads a handful of values out of the running game
-      and prints a report you can paste into a GitHub issue.
-
-    IT WRITES NOTHING
-      No patching, no modification, no side effects. Verify it yourself: the only
-      three functions it imports from kernel32 are OpenProcess, ReadProcessMemory
-      and CloseHandle. No write function is declared at all, so it could not
-      modify the game even if it tried.
+    IT WRITES NOTHING TO HITMAN
+      No game patching or process-memory modification. Verify it yourself: the
+      only three functions it imports from kernel32 are OpenProcess,
+      ReadProcessMemory and CloseHandle. No process-memory write function is
+      declared at all, so it could not modify the game even if it tried. The
+      Copy and Save buttons only copy or save the displayed report on request.
 
       The process is opened with access mask 0x0410, which is
       PROCESS_QUERY_INFORMATION together with PROCESS_VM_READ. No write right is
@@ -74,14 +72,15 @@ $ACCESS = 0x0410
 $VERIFIED_TIMESTAMP = 1781013974
 
 $SIGS = [ordered]@{
-  "layer writer A"   = @{ Pattern="8B 97 D8 04 00 00 83 FA 01 0F 94 C1 88 8F 1B 03 00 00"; Hit=9 }
-  "layer writer B"   = @{ Pattern="8B 97 D8 04 00 00 83 FA 01 0F 94 C0 88 87 1B 03 00 00"; Hit=9 }
-  "field of view"    = @{ Pattern="C0 08 00 00 45 33 C0 4C 8B 8E C8 7A 00 00 48 8B D3 48 89 6C 24 28 48 89 6C 24 20 48 8B 01 FF 50 28 48 8B CB E8 ?? ?? ?? ?? FF 4B 14 0F B6 87 1B 03 00 00"; Hit=44 }
-  "view count"       = @{ Pattern="74 16 49 8B 85 A0 41 01 00 41 8B CF 80 B8 1B 03 00 00 00 0F 45 CF"; Hit=12 }
+  "layer writer A"   = @{ Pattern="8B 97 D8 04 00 00 83 FA 01 0F 94 C1 88 8F 1B 03 00 00"; Hit=9; Stock=[byte[]](0x0F,0x94,0xC1); Fix=[byte[]](0xB1,0x00,0x90) }
+  "layer writer B"   = @{ Pattern="8B 97 D8 04 00 00 83 FA 01 0F 94 C0 88 87 1B 03 00 00"; Hit=9; Stock=[byte[]](0x0F,0x94,0xC0); Fix=[byte[]](0xB0,0x00,0x90) }
+  "field of view A"  = @{ Pattern="C0 08 00 00 45 33 C0 4C 8B 8E C8 7A 00 00 48 8B D3 48 89 6C 24 28 48 89 6C 24 20 48 8B 01 FF 50 28 48 8B CB E8 ?? ?? ?? ?? FF 4B 14 0F B6 87 1B 03 00 00"; Hit=44; Stock=[byte[]](0x0F,0xB6,0x87,0x1B,0x03,0x00,0x00); Fix=[byte[]](0xB8,0x01,0x00,0x00,0x00,0x90,0x90) }
+  "field of view B"  = @{ Pattern="50 09 00 00 45 33 C0 4C 8B 8E C8 7A 00 00 48 8B D3 48 89 6C 24 28 48 89 6C 24 20 48 8B 01 FF 50 28 48 8B CB E8 ?? ?? ?? ?? FF 4B 14 0F B6 87 1B 03 00 00"; Hit=44; Stock=[byte[]](0x0F,0xB6,0x87,0x1B,0x03,0x00,0x00); Fix=[byte[]](0xB8,0x01,0x00,0x00,0x00,0x90,0x90) }
+  "view count"       = @{ Pattern="74 16 49 8B 85 A0 41 01 00 41 8B CF 80 B8 1B 03 00 00 00 0F 45 CF"; Hit=12; Stock=[byte[]](0x80,0xB8,0x1B,0x03,0x00,0x00,0x00); Fix=[byte[]](0x48,0x85,0xE4,0x90,0x90,0x90,0x90) }
   "device locator"   = @{ Pattern="48 8B 0D ?? ?? ?? ?? 8B D6 48 8B 01 44 38 B9 1B 03 00 00 0F 84"; Hit=0 }
 }
 
-# offsets as known from the Oculus device
+# shared offsets observed on the Oculus and OpenVR device classes
 $FIELDS = [ordered]@{
   "mode          +0x220" = @{ Off=0x220L; Type="u32" }
   "cached mode   +0x30C" = @{ Off=0x30CL; Type="u32" }
@@ -104,6 +103,10 @@ function RB { param([IntPtr]$h,[Int64]$a,[int]$n)
     if (-not [HmProbe]::ReadProcessMemory($h,[IntPtr]$a,$b,$n,[ref]$r) -or $r.ToInt64() -ne $n) { return $null }
     return ,$b }
 function Hex { param([byte[]]$B) if ($null -eq $B) { "unreadable" } else { ($B|ForEach-Object{$_.ToString("X2")}) -join " " } }
+function Same { param([byte[]]$A,[byte[]]$B)
+    if ($null -eq $A -or $null -eq $B -or $A.Length -ne $B.Length) { return $false }
+    for ($i=0;$i -lt $A.Length;$i++) { if ($A[$i] -ne $B[$i]) { return $false } }
+    return $true }
 
 function Find-Sig { param([byte[]]$hay,[string]$pat)
     $tok=$pat.Split(" "); $n=$tok.Count
@@ -120,7 +123,7 @@ function Find-Sig { param([byte[]]$hay,[string]$pat)
 
 function Build-Report {
     $L = New-Object Collections.Generic.List[string]
-    $L.Add("HitmanVRProbe 1.0 - read-only report")
+    $L.Add("HitmanVRProbe 1.1 - read-only report")
     $L.Add("generated " + (Get-Date -Format "yyyy-MM-dd HH:mm:ss"))
     $L.Add("")
 
@@ -155,12 +158,14 @@ function Build-Report {
 
     # patterns
     $L.Add("--- code patterns ---")
-    $devRVA=0L; $wnoOff=0L
+    $devRVA=0L; $wnoOff=0L; $patchSites=@()
     foreach ($k in $SIGS.Keys) {
         $h=@(Find-Sig $text $SIGS[$k].Pattern)
         if ($h.Count -eq 1) {
             $rva=$tRVA+$h[0]+$SIGS[$k].Hit
             $L.Add(("{0,-16} : found, 1 hit, RVA 0x{1:X7}" -f $k,$rva))
+            if ($null -ne $SIGS[$k].Fix) {
+                $patchSites += [pscustomobject]@{ Name=$k; RVA=[int64]$rva; Stock=$SIGS[$k].Stock; Fix=$SIGS[$k].Fix } }
             if ($k -eq "device locator") {
                 $rel=[BitConverter]::ToInt32($text,$h[0]+3)
                 $devRVA=[int64]($tRVA+$h[0]+7+$rel)
@@ -174,28 +179,37 @@ function Build-Report {
     $hnd=[HmProbe]::OpenProcess($ACCESS,$false,$p.Id)
     if ($hnd -eq [IntPtr]::Zero) { $L.Add("Could not open the process for reading. Run as administrator."); return ($L -join "`r`n") }
     try {
+        $L.Add("--- live code ---")
+        foreach ($s in $patchSites) {
+            $cur=RB $hnd ($base+$s.RVA) $s.Fix.Length
+            $status=if ($null -eq $cur) { "unreadable" } elseif (Same $cur $s.Fix) { "fixed" } elseif (Same $cur $s.Stock) { "stock" } else { "other: " + (Hex $cur) }
+            $L.Add(("{0,-16} : {1}" -f $s.Name,$status)) }
+        $L.Add("")
+
         $L.Add("--- live device ---")
         if ($devRVA -eq 0) { $L.Add("device pointer could not be located, nothing further to read") }
         else {
             $pb = RB $hnd ($base+$devRVA) 8
-            $dev = if ($pb) { [BitConverter]::ToInt64($pb,0) } else { 0 }
+            $dev = if ($null -ne $pb) { [BitConverter]::ToInt64($pb,0) } else { 0 }
             if ($dev -eq 0) { $L.Add("device pointer is null - VR is not running yet. Get into VR and a mission, then Refresh.") }
             else {
                 $vt = RB $hnd $dev 8
-                $vtRVA = if ($vt) { [BitConverter]::ToInt64($vt,0) - $base } else { 0 }
                 $L.Add(("device object        : 0x{0:X}" -f $dev))
-                $L.Add(("device vtable RVA    : 0x{0:X7}   <-- this identifies the backend class" -f $vtRVA))
+                if ($null -ne $vt) {
+                    $vtRVA=[BitConverter]::ToInt64($vt,0)-$base
+                    $L.Add(("device vtable RVA    : 0x{0:X7}   <-- this identifies the backend class" -f $vtRVA)) }
+                else { $L.Add("device vtable RVA    : unreadable") }
                 $L.Add("")
                 foreach ($k in $FIELDS.Keys) {
                     $f=$FIELDS[$k]; $a=$dev+$f.Off
                     switch ($f.Type) {
-                        "u8"  { $r=RB $hnd $a 1;  $v=if($r){"{0}" -f $r[0]}else{"unreadable"} }
-                        "u16" { $r=RB $hnd $a 2;  $v=if($r){"{0}" -f [BitConverter]::ToUInt16($r,0)}else{"unreadable"} }
-                        "u32" { $r=RB $hnd $a 4;  $v=if($r){"{0}" -f [BitConverter]::ToUInt32($r,0)}else{"unreadable"} }
-                        "ptr" { $r=RB $hnd $a 8;  $v=if($r){"0x{0:X}" -f [BitConverter]::ToInt64($r,0)}else{"unreadable"} }
-                        "f1"  { $r=RB $hnd $a 4;  $v=if($r){"{0,-12:0.######}  raw {1}" -f [BitConverter]::ToSingle($r,0),(Hex $r)}else{"unreadable"} }
+                        "u8"  { $r=RB $hnd $a 1;  $v=if($null -ne $r){"{0}" -f $r[0]}else{"unreadable"} }
+                        "u16" { $r=RB $hnd $a 2;  $v=if($null -ne $r){"{0}" -f [BitConverter]::ToUInt16($r,0)}else{"unreadable"} }
+                        "u32" { $r=RB $hnd $a 4;  $v=if($null -ne $r){"{0}" -f [BitConverter]::ToUInt32($r,0)}else{"unreadable"} }
+                        "ptr" { $r=RB $hnd $a 8;  $v=if($null -ne $r){"0x{0:X}" -f [BitConverter]::ToInt64($r,0)}else{"unreadable"} }
+                        "f1"  { $r=RB $hnd $a 4;  $v=if($null -ne $r){"{0,-12:0.######}  raw {1}" -f [BitConverter]::ToSingle($r,0),(Hex $r)}else{"unreadable"} }
                         "f4"  { $r=RB $hnd $a 16
-                                if ($r) { $fl=@(); for($i=0;$i -lt 4;$i++){$fl+=("{0:0.######}" -f [BitConverter]::ToSingle($r,$i*4))}
+                                if ($null -ne $r) { $fl=@(); for($i=0;$i -lt 4;$i++){$fl+=("{0:0.######}" -f [BitConverter]::ToSingle($r,$i*4))}
                                           $v=("{0}   raw {1}" -f (($fl -join ", ").PadRight(38)),(Hex $r)) } else { $v="unreadable" } }
                     }
                     $L.Add(("{0,-22} : {1}" -f $k,$v)) } } }
@@ -215,7 +229,7 @@ $form.Font=New-Object Drawing.Font("Segoe UI",9)
 
 $hdr=New-Object Windows.Forms.Label
 $hdr.Location=New-Object Drawing.Point(14,12); $hdr.Size=New-Object Drawing.Size(732,40)
-$hdr.Text="This reads a few values out of the running game and writes nothing at all. Start HITMAN, get into VR and into a mission, then press Refresh."
+$hdr.Text="This only reads the running game; Copy/Save affect the report, never game memory. Start HITMAN, enter VR and a mission, then press Refresh."
 $form.Controls.Add($hdr)
 
 $box=New-Object Windows.Forms.TextBox


### PR DESCRIPTION
## Summary

- neutralize the renderer values before SteamVR / OpenVR builds its cached render state
- track real renderer transitions instead of texture-pointer identity
- require verified readback and a stability window before reporting Active
- make code patching, rollback, device recreation and restore safer
- update the diagnostic to HitmanVRProbe 1.1
- add v1.3 release notes and verified SteamVR / Freelancer documentation

## Root cause

v1.2 polled every 250 ms and treated texture-pointer changes as mission generations. On fast OpenVR loads, the renderer could cache the old scale and mask values before the tool wrote them; allocator pointer reuse could then prevent the reload state from being reset. This produced intermittent black circles or an overbright image even though a later probe showed neutral CPU-side values.

## Validation

- PowerShell parser checks pass for the main tool and probe
- render lifecycle, reload, transient read/write failure, rollback and stale-device tests pass
- visually verified in the headset with a new mission, mission restart, save-game load, scene change and Freelancer mode
- final release ZIP manifest and contents verified byte-for-byte

Addresses #1, #2, #3 and #4.