### PR TITLE
Release v1.4

### DIFF
--- a/CHANGELOG-v1.4.md
+++ b/CHANGELOG-v1.4.md
@@ -1,0 +1,32 @@
+# HitmanVRFoveationFix v1.4
+
+## Fixed
+
+- Glass, flowing water, bottles and affected emissive/light materials no longer
+  render different content in the left and right eye.
+- Angle-dependent simultaneous pop-in of affected panes, NPC glasses and lights is
+  removed by limiting only the two `CopyRefractionDepth` calls to the two physical
+  eye views. Geometry and visibility retain the required four logical views.
+- A separate sleeping renderer guard reduces the save-load observation window from
+  up to 15 ms to approximately 1 ms. Its fast path reads only the 16-byte scale and
+  8-byte mask fields and performs no writes while they match.
+- Guard corrections reuse the full v1.3 validation, ownership, write, verification
+  and rollback transaction. A transition-3 write is latched across the next normal
+  lifecycle sample.
+
+## Preserved
+
+- The WinForms UI, device detection and lifecycle loop remain at 15 ms.
+- Oculus and SteamVR/OpenVR use the same verified renderer-value handling.
+- Build 3.270.1 uses exact verified addresses and contexts. Other builds retain a
+  fail-closed pattern path, now including three strong refraction call patterns.
+- Turning the tool off or closing it restores owned renderer values and code when a
+  live restore can be proven safe. Closing HITMAN always discards all changes.
+
+## Test basis
+
+The refraction split is the former Transparency TestKit 7 **Test W**. It was reported
+correct across the previously affected villa panes, NPC glasses, flowing water,
+lights, panorama glass and aquarium scenes, with no remaining stereo mismatch,
+simultaneous pop-in or angle-dependent brightness change. The W telemetry log showed
+balanced owner and CopyRefractionDepth scopes with no rejected states.

--- a/HitmanVRFoveationFix.bat
+++ b/HitmanVRFoveationFix.bat
@@ -1,4 +1,4 @@
 @echo off
-rem  Double-click this file to start HitmanVRFoveationFix.
+rem  Double-click this file to start HitmanVRFoveationFix v1.4.
 rem  It only launches the PowerShell script that sits next to it.
 start "" powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "%~dp0HitmanVRFoveationFix.ps1"

--- a/HitmanVRFoveationFix.ps1
+++ b/HitmanVRFoveationFix.ps1
@@ -1,6 +1,17 @@
 <#
-    HitmanVRFoveationFix  v1.3
-    Edge-to-edge sharpness for HITMAN World of Assassination in PC VR.
+    HitmanVRFoveationFix v1.4
+
+    v1.4 adds two deliberately separate fixes to the proven v1.3 base:
+
+      - Refraction-depth copies use the two physical eye views while the
+        geometry/visibility renderer keeps its required four logical views.
+        This fixes stereo glass, water, bottles and affected lights without
+        reintroducing geometry pop-in.
+
+      - A sleeping ~1 ms guard watches only the 24 critical renderer bytes.
+        It performs no writes while they are correct. If HITMAN briefly restores
+        its foveation values during a save load, the guard hands the repair to
+        the same validated sync/write/verify/rollback routine as the 15 ms loop.
 
     WHAT IT DOES
       HITMAN renders VR with foveation: four layers per frame, two wide ones at
@@ -21,15 +32,11 @@
       2. Start HITMAN - however you like, including straight into VR
       3. Play
 
-    TWO MODES
-      On build 3.270.1, the build this was developed and tested on, the tool
-      uses fixed, verified addresses - exactly the code path that was tested.
-
-      On any other build it searches for the relevant code by byte pattern.
-      Addresses move with every rebuild of the game, the surrounding
-      instructions do not. If every pattern is found exactly once the tool
-      works and says the build is untested. If anything is ambiguous or
-      missing, it refuses and changes nothing.
+    BUILD HANDLING
+      Build 3.270.1 uses the exact addresses and instruction contexts that were
+      developed and tested. Other builds retain the conservative v1.3 pattern
+      path: every base and refraction hook pattern must be unique, mutually
+      consistent and in its original state or the tool refuses to write.
 
     SUPPORTED HEADSETS
       Both VR backends the game speaks are supported:
@@ -63,6 +70,19 @@ param([string]$ProcessName = "HITMAN3")
 
 $ErrorActionPreference = "Stop"
 
+$FIX_VERSION = "1.4"
+$MODE_INFO = [pscustomobject]@{
+    Short="v1.4"
+    Title="HitmanVRFoveationFix v1.4"
+    Warning=""
+    UsesHook=$true
+    HookKinds=@("Outer","CopyA","CopyB")
+    OuterChangesCount=$false
+    CopyFrom=4
+    CopyTo=2
+    UsesMesh4=$false
+}
+
 # Reading another process's memory needs administrator rights. If we do not
 # have them, ask Windows for them once and restart ourselves.
 $me = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
@@ -71,7 +91,8 @@ if (-not $me.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     if (-not $self) { $self = $MyInvocation.MyCommand.Definition }
     try {
         Start-Process -FilePath "powershell.exe" -Verb RunAs -ArgumentList @(
-            "-NoProfile","-ExecutionPolicy","Bypass","-WindowStyle","Hidden","-File","`"$self`"")
+            "-NoProfile","-ExecutionPolicy","Bypass","-WindowStyle","Hidden",
+            "-File","`"$self`"","-ProcessName","`"$ProcessName`"")
     } catch {
         Add-Type -AssemblyName System.Windows.Forms
         [Windows.Forms.MessageBox]::Show(
@@ -83,6 +104,12 @@ if (-not $me.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
 
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
+if (-not [Environment]::Is64BitProcess) {
+    [Windows.Forms.MessageBox]::Show(
+        "HitmanVRFoveationFix v1.4 requires 64-bit Windows PowerShell so live code changes can be verified safely.",
+        "HitmanVRFoveationFix","OK","Warning") | Out-Null
+    exit
+}
 
 # Two instances can both observe stock code before either writes it, then each
 # believe it owns the patch. A named mutex closes that race before any game
@@ -103,6 +130,8 @@ if (-not ("HmFix" -as [type])) {
     Add-Type -TypeDefinition @'
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Windows.Forms;
 public static class HmFix {
     [DllImport("kernel32.dll", SetLastError=true)]
     public static extern IntPtr OpenProcess(uint a, bool i, int p);
@@ -112,16 +141,162 @@ public static class HmFix {
     public static extern bool WriteProcessMemory(IntPtr h, IntPtr addr, byte[] buf, int size, out IntPtr written);
     [DllImport("kernel32.dll", SetLastError=true)]
     public static extern bool FlushInstructionCache(IntPtr h, IntPtr addr, UIntPtr size);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern IntPtr VirtualAllocEx(IntPtr h, IntPtr addr, UIntPtr size, uint allocationType, uint protect);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern bool VirtualProtectEx(IntPtr h, IntPtr addr, UIntPtr size, uint newProtect, out uint oldProtect);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern IntPtr OpenThread(uint access, bool inheritHandle, uint threadId);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern uint SuspendThread(IntPtr thread);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern uint ResumeThread(IntPtr thread);
+    [DllImport("kernel32.dll", EntryPoint="GetThreadContext", SetLastError=true)]
+    private static extern bool GetThreadContextNative(IntPtr thread, IntPtr context);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern bool GetProcessMitigationPolicy(IntPtr process, uint policy, out uint buffer, UIntPtr length);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
     [DllImport("kernel32.dll")]
     public static extern bool CloseHandle(IntPtr h);
+
+    // AMD64 CONTEXT is 16-byte aligned. ContextFlags is at +48 and RIP at
+    // +248. CONTEXT_CONTROL is sufficient and keeps this helper independent
+    // of the large floating-point/vector tail of the structure.
+    public static bool TryGetThreadRip(IntPtr thread, out ulong rip, out int error) {
+        const int SIZE = 0x4D0;
+        rip = 0; error = 0;
+        if (!Environment.Is64BitProcess) { error = 193; return false; }
+        IntPtr raw = Marshal.AllocHGlobal(SIZE + 15);
+        try {
+            long alignedValue = (raw.ToInt64() + 15L) & ~15L;
+            IntPtr aligned = new IntPtr(alignedValue);
+            for (int i = 0; i < SIZE; i += 8) Marshal.WriteInt64(aligned, i, 0L);
+            Marshal.WriteInt32(aligned, 0x30, unchecked((int)0x00100001u));
+            if (!GetThreadContextNative(thread, aligned)) {
+                error = Marshal.GetLastWin32Error(); return false;
+            }
+            rip = unchecked((ulong)Marshal.ReadInt64(aligned, 0xF8));
+            return true;
+        } finally { Marshal.FreeHGlobal(raw); }
+    }
 }
-'@
+
+// The fast renderer guard never writes process memory. Its background thread
+// reads only the 16-byte scale and 8-byte mask fields. A mismatch is marshalled
+// once to the WinForms thread, where PowerShell runs the existing validated
+// renderer transaction. This keeps PowerShell and all writes single-threaded.
+public sealed class RendererValueGuard : IDisposable {
+    private readonly IntPtr process;
+    private readonly long device;
+    private readonly long scaleOffset;
+    private readonly long maskOffset;
+    private readonly byte[] expectedScale;
+    private readonly byte[] expectedMask;
+    private readonly Control dispatcher;
+    private readonly Action<RendererValueGuard> callback;
+    private readonly ManualResetEvent stop = new ManualResetEvent(false);
+    private readonly Thread thread;
+    private int signalPending;
+    private int stopped;
+    private long reads;
+    private long mismatches;
+    private long readFailures;
+
+    public RendererValueGuard(IntPtr process, long device, long scaleOffset,
+        long maskOffset, byte[] expectedScale, byte[] expectedMask,
+        Control dispatcher, Action<RendererValueGuard> callback) {
+        if (process == IntPtr.Zero) throw new ArgumentException("process");
+        if (device == 0) throw new ArgumentException("device");
+        if (expectedScale == null || expectedScale.Length != 16) throw new ArgumentException("scale");
+        if (expectedMask == null || expectedMask.Length != 8) throw new ArgumentException("mask");
+        if (dispatcher == null || callback == null) throw new ArgumentNullException();
+        this.process = process;
+        this.device = device;
+        this.scaleOffset = scaleOffset;
+        this.maskOffset = maskOffset;
+        this.expectedScale = (byte[])expectedScale.Clone();
+        this.expectedMask = (byte[])expectedMask.Clone();
+        this.dispatcher = dispatcher;
+        this.callback = callback;
+        thread = new Thread(Run);
+        thread.IsBackground = true;
+        thread.Name = "HitmanVR renderer guard";
+    }
+
+    public long Device { get { return device; } }
+    public bool IsRunning { get { return Volatile.Read(ref stopped) == 0 && thread.IsAlive; } }
+    public long Reads { get { return Interlocked.Read(ref reads); } }
+    public long Mismatches { get { return Interlocked.Read(ref mismatches); } }
+    public long ReadFailures { get { return Interlocked.Read(ref readFailures); } }
+
+    public void Start() { thread.Start(); }
+
+    private static bool EqualBytes(byte[] left, byte[] right) {
+        if (left.Length != right.Length) return false;
+        for (int i = 0; i < left.Length; i++) if (left[i] != right[i]) return false;
+        return true;
+    }
+
+    private bool ReadExact(long address, byte[] buffer) {
+        IntPtr read;
+        return HmFix.ReadProcessMemory(process, new IntPtr(address), buffer,
+            buffer.Length, out read) && read.ToInt64() == buffer.Length;
+    }
+
+    private void Run() {
+        byte[] scale = new byte[16];
+        byte[] mask = new byte[8];
+        try {
+            while (!stop.WaitOne(1)) {
+                bool scaleRead = ReadExact(device + scaleOffset, scale);
+                bool maskRead = scaleRead && ReadExact(device + maskOffset, mask);
+                if (!scaleRead || !maskRead) {
+                    Interlocked.Increment(ref readFailures);
+                    continue;
+                }
+                Interlocked.Increment(ref reads);
+                if (EqualBytes(scale, expectedScale) && EqualBytes(mask, expectedMask)) continue;
+                Interlocked.Increment(ref mismatches);
+                if (Interlocked.CompareExchange(ref signalPending, 1, 0) != 0) continue;
+                try {
+                    if (stop.WaitOne(0) || dispatcher.IsDisposed || !dispatcher.IsHandleCreated) {
+                        Interlocked.Exchange(ref signalPending, 0);
+                        continue;
+                    }
+                    dispatcher.BeginInvoke(callback, new object[] { this });
+                } catch {
+                    Interlocked.Exchange(ref signalPending, 0);
+                }
+            }
+        } finally {
+            Interlocked.Exchange(ref stopped, 1);
+        }
+    }
+
+    public void CompleteSignal() { Interlocked.Exchange(ref signalPending, 0); }
+
+    public bool Stop(int milliseconds) {
+        stop.Set();
+        if (Thread.CurrentThread == thread) return false;
+        bool joined = !thread.IsAlive || thread.Join(milliseconds);
+        if (joined) Interlocked.Exchange(ref stopped, 1);
+        return joined;
+    }
+
+    public void Dispose() {
+        Stop(2000);
+        stop.Dispose();
+    }
+}
+'@ -ReferencedAssemblies @("System.Windows.Forms")
 }
 
 # ===========================================================================
-#  VERIFIED PATH - build 3.270.1, tested, unchanged from v1.0
+#  VERIFIED PATH - build 3.270.1; v1.3 base plus the confirmed v1.4 W fix
 # ===========================================================================
 $VERIFIED_TIMESTAMP    = 1781013974
+$VERIFIED_SHA256       = "B4FB04F460FD67E67F21264D7AD0D64BC081FBA62EC71E36B898D04DB9E8620D"
 $MANAGER_RVA           = 0x03225D20L
 $MANAGER_VTABLE_RVA    = 0x01EF5398L
 $MANAGER_DEVICE_OFFSET = 0x141A0L
@@ -129,23 +304,238 @@ $OCULUS_VTABLE_RVA     = 0x01F016C0L    # ZRenderVRDeviceOculus
 $OPENVR_VTABLE_RVA     = 0x01EFE020L    # ZRenderVRDeviceOpenVR - same layout, verified by probe
 $VERIFIED_WNO_OFF      = 0x31BL
 
-$VERIFIED_CODE = @(
-  [pscustomobject]@{ RVA=0x011D8B9EL
+$VERIFIED_WNO_WRITERS = @(
+  [pscustomobject]@{ Name="v1.3 WNO writer A"
+                     RVA=0x011D8B9EL
                      Stock=[byte[]](0x0F,0x94,0xC1)
                      Fix  =[byte[]](0xB1,0x00,0x90) }
-  [pscustomobject]@{ RVA=0x011D8BC1L
+  [pscustomobject]@{ Name="v1.3 WNO writer B"
+                     RVA=0x011D8BC1L
                      Stock=[byte[]](0x0F,0x94,0xC0)
                      Fix  =[byte[]](0xB0,0x00,0x90) }
-  [pscustomobject]@{ RVA=0x012C1EACL          # field of view, Oculus device
+)
+
+$VERIFIED_PRIMARY_DEPTH_CB = @(
+  [pscustomobject]@{ Name="v1.3 depth flag Oculus"
+                     RVA=0x012C1EACL          # primary depth/tile CB flag, Oculus
                      Stock=[byte[]](0x0F,0xB6,0x87,0x1B,0x03,0x00,0x00)
                      Fix  =[byte[]](0xB8,0x01,0x00,0x00,0x00,0x90,0x90) }
-  [pscustomobject]@{ RVA=0x012499CCL          # field of view, OpenVR device
+  [pscustomobject]@{ Name="v1.3 depth flag OpenVR"
+                     RVA=0x012499CCL          # primary depth/tile CB flag, OpenVR
                      Stock=[byte[]](0x0F,0xB6,0x87,0x1B,0x03,0x00,0x00)
                      Fix  =[byte[]](0xB8,0x01,0x00,0x00,0x00,0x90,0x90) }
-  [pscustomobject]@{ RVA=0x01161FE9L
+)
+
+$VERIFIED_VIEW_COUNT =
+  [pscustomobject]@{ Name="v1.3 view count"
+                     RVA=0x01161FE9L
+                     Stock=[byte[]](0x80,0xB8,0x1B,0x03,0x00,0x00,0x00)
+                     Fix  =[byte[]](0x48,0x85,0xE4,0x90,0x90,0x90,0x90) }
+
+# Most experimental sites below take one locally WNO-dependent producer or
+# consumer down the stock WNO=1 path while the device itself remains in v1.3's
+# two-slice state. `test rsp,rsp` plus NOPs makes ZF=0 without changing control
+# flow or using new executable memory. CopyRefractionDepth is the one exception:
+# its three-byte load is replaced with a same-size base-slice-zero assignment.
+$REFRACTION_DEPTH_ZERO =
+  [pscustomobject]@{ Name="CopyRefractionDepth base slice zero"
+                     RVA=0x0128FF20L
+                     Stock=[byte[]](0x8B,0x6E,0x20)
+                     Fix  =[byte[]](0x31,0xED,0x90) }
+
+$CAMERA_STATE_4 =
+  [pscustomobject]@{ Name="extended camera state"
+                     RVA=0x011B4625L
+                     Stock=[byte[]](0x44,0x38,0xB9,0x1B,0x03,0x00,0x00)
+                     Fix  =[byte[]](0x48,0x85,0xE4,0x90,0x90,0x90,0x90) }
+
+$ASSAO_DEPTH_4 =
+  [pscustomobject]@{ Name="four-view ASSAO depth preparation"
+                     RVA=0x012886DAL
+                     Stock=[byte[]](0x80,0xB8,0x1B,0x03,0x00,0x00,0x00)
+                     Fix  =[byte[]](0x48,0x85,0xE4,0x90,0x90,0x90,0x90) }
+
+$CAMERA_RECORDS_4 =
+  [pscustomobject]@{ Name="four-view camera records"
+                     RVA=0x0129297EL
+                     Stock=[byte[]](0x80,0xB8,0x1B,0x03,0x00,0x00,0x00)
+                     Fix  =[byte[]](0x48,0x85,0xE4,0x90,0x90,0x90,0x90) }
+
+$OCCLUDER_STATE_4 = @(
+  [pscustomobject]@{ Name="occluder matrix preprocess"
+                     RVA=0x01298B1DL
+                     Stock=[byte[]](0x44,0x38,0xA8,0x1B,0x03,0x00,0x00)
+                     Fix  =[byte[]](0x48,0x85,0xE4,0x90,0x90,0x90,0x90) }
+  [pscustomobject]@{ Name="occluder matrix restore"
+                     RVA=0x0129987CL
                      Stock=[byte[]](0x80,0xB8,0x1B,0x03,0x00,0x00,0x00)
                      Fix  =[byte[]](0x48,0x85,0xE4,0x90,0x90,0x90,0x90) }
 )
+
+$SSR_FRUSTA_4 =
+  [pscustomobject]@{ Name="four-view SSR frusta"
+                     RVA=0x0129DE92L
+                     Stock=[byte[]](0x80,0xB8,0x1B,0x03,0x00,0x00,0x00)
+                     Fix  =[byte[]](0x48,0x85,0xE4,0x90,0x90,0x90,0x90) }
+
+$CORE_DRAW_GATES_4 = @(
+  [pscustomobject]@{ Name="core DrawGate A"
+                     RVA=0x01296BEFL
+                     Stock=[byte[]](0x40,0x38,0xB0,0x1B,0x03,0x00,0x00)
+                     Fix  =[byte[]](0x48,0x85,0xE4,0x90,0x90,0x90,0x90) }
+  [pscustomobject]@{ Name="core DrawGate B"
+                     RVA=0x0129706CL
+                     Stock=[byte[]](0x80,0xB8,0x1B,0x03,0x00,0x00,0x00)
+                     Fix  =[byte[]](0x48,0x85,0xE4,0x90,0x90,0x90,0x90) }
+)
+
+# With the global render-context count left at two, this changes only the
+# instance-multiplier constant consumed by CullScatter's visibility shader.
+# CullScatter's other two tests distinguish one view from more than one, so
+# their behaviour is identical for the two-view and four-view profiles.
+$CULL_SCATTER_4 =
+  [pscustomobject]@{ Name="CullScatter instance multiplier four"
+                     RVA=0x0127AABBL
+                     Stock=[byte[]](0x41,0x8B,0x46,0x14,0x41,0x8B,0x0C,0x86)
+                     Fix  =[byte[]](0xB9,0x04,0x00,0x00,0x00,0x90,0x90,0x90) }
+
+# v1.4 redirects only exact instruction blocks. Every replacement uses a
+# normal indirect CALL followed by an inline jump over its 64-bit pointer. The
+# private wrapper returns normally, so Windows shadow-stack/CET CALL/RET symmetry
+# is retained. No replacement consumes another engine context-stack slot.
+$TRANSPARENT_PASS_CALL =
+  [pscustomobject]@{ Name="DrawRefractiveAndTransparent camera call"
+                     Kind="Outer"
+                     RVA=0x011B892AL
+                     TargetRVA=0x01290220L
+                     ContinuationRVA=0x011B893CL
+                     UnitOffset=0x000L
+                     Stock=[byte[]](0x48,0x8B,0x8C,0x24,0xC0,0x00,0x00,0x00,0x48,0x89,0x44,0x24,0x20,0xE8,0xE4,0x78,0x0D,0x00) }
+
+$COPY_DEPTH_CALL_A =
+  [pscustomobject]@{ Name="CopyRefractionDepth call A"
+                     Kind="CopyA"
+                     RVA=0x01290BA2L
+                     TargetRVA=0x0128FE20L
+                     ContinuationRVA=0x01290BB7L
+                     UnitOffset=0x400L
+                     CounterOffset=0x60L
+                     Stock=[byte[]](0x4D,0x8B,0xC4,0x8B,0x41,0x04,0x44,0x8B,0x09,0x48,0x8B,0xCE,0x89,0x44,0x24,0x20,0xE8,0x69,0xF2,0xFF,0xFF) }
+
+$COPY_DEPTH_CALL_B =
+  [pscustomobject]@{ Name="CopyRefractionDepth call B"
+                     Kind="CopyB"
+                     RVA=0x01291386L
+                     TargetRVA=0x0128FE20L
+                     ContinuationRVA=0x0129139BL
+                     UnitOffset=0x600L
+                     CounterOffset=0x80L
+                     Stock=[byte[]](0x4D,0x8B,0xC4,0x8B,0x41,0x04,0x44,0x8B,0x09,0x48,0x8B,0xCE,0x89,0x44,0x24,0x20,0xE8,0x85,0xEA,0xFF,0xFF) }
+
+$MESH_COUNT_HOOK =
+  [pscustomobject]@{ Name="transparent indexed-mesh instance multiplier"
+                     Kind="Mesh"
+                     RVA=0x0121C91AL
+                     ContinuationRVA=0x0121C92BL
+                     UnitOffset=0x200L
+                     Stock=[byte[]](0x8B,0x41,0x14,0x41,0x8B,0xE9,0x45,0x8B,0xF0,0x8B,0xF2,0x48,0x8B,0xD9,0x8B,0x3C,0x81) }
+
+# The old water wrapper and the unrelated particle-lighting multiplier are
+# stock-only guards. Test S already proved that the water wrapper adds nothing;
+# reverse engineering proved the sprite multiplier runs before this pass.
+$WATER_PASS_CALL =
+  [pscustomobject]@{ Name="DrawWaterRefractive camera call"
+                     Kind="WaterGuard"
+                     RVA=0x011B83CAL
+                     TargetRVA=0x0127E260L
+                     ContinuationRVA=0x011B83E1L
+                     Stock=[byte[]](0x48,0x8D,0x84,0x24,0xE0,0x01,0x00,0x00,0x48,0x89,0x5C,0x24,0x28,0x48,0x89,0x44,0x24,0x20,0xE8,0x7F,0x5E,0x0C,0x00) }
+$SPRITE_COUNT_GUARD =
+  [pscustomobject]@{ Name="unrelated particle-lighting instance multiplier"
+                     Kind="SpriteGuard"
+                     RVA=0x012EB2B4L
+                     Stock=[byte[]](0x48,0x8B,0xCB,0x44,0x8D,0x42,0x14,0x0F,0xB7,0x74,0xC7,0x32,0x8B,0x43,0x14,0x0F,0xAF,0x34,0x83) }
+
+# Publish all inner blocks first and the outer camera entry last. Reverse
+# rollback therefore removes the entry gate first even on a partial failure.
+$ALL_HOOK_SITES=@($COPY_DEPTH_CALL_A,$COPY_DEPTH_CALL_B,$MESH_COUNT_HOOK,$TRANSPARENT_PASS_CALL)
+
+# Exact on-disk instruction contexts for every profile-sensitive site. Each
+# sequence is unique in build 3.270.1.
+$VERIFIED_DIAGNOSTIC_CONTEXTS = @(
+  [pscustomobject]@{ RVA=0x012499A0L
+                     Bytes=[byte[]](0x50,0x09,0x00,0x00,0x45,0x33,0xC0,0x4C,0x8B,0x8E,0xC8,0x7A,0x00,0x00,0x48,0x8B,0xD3,0x48,0x89,0x6C,0x24,0x28,0x48,0x89,0x6C,0x24,0x20,0x48,0x8B,0x01,0xFF,0x50,0x28,0x48,0x8B,0xCB,0xE8,0x57,0x66,0xFD,0xFF,0xFF,0x4B,0x14,0x0F,0xB6,0x87,0x1B,0x03,0x00,0x00) }
+  [pscustomobject]@{ RVA=0x012C1E80L
+                     Bytes=[byte[]](0xC0,0x08,0x00,0x00,0x45,0x33,0xC0,0x4C,0x8B,0x8E,0xC8,0x7A,0x00,0x00,0x48,0x8B,0xD3,0x48,0x89,0x6C,0x24,0x28,0x48,0x89,0x6C,0x24,0x20,0x48,0x8B,0x01,0xFF,0x50,0x28,0x48,0x8B,0xCB,0xE8,0x77,0xE1,0xF5,0xFF,0xFF,0x4B,0x14,0x0F,0xB6,0x87,0x1B,0x03,0x00,0x00) }
+  [pscustomobject]@{ RVA=0x01296BEAL
+                     Bytes=[byte[]](0xB9,0x03,0x00,0x00,0x00,0x40,0x38,0xB0,0x1B,0x03,0x00,0x00,0x41,0x0F,0x44,0xCF,0x44,0x3B,0xC9,0x0F,0x83) }
+  [pscustomobject]@{ RVA=0x01297067L
+                     Bytes=[byte[]](0xB9,0x03,0x00,0x00,0x00,0x80,0xB8,0x1B,0x03,0x00,0x00,0x00,0x41,0x0F,0x44,0xC9,0x3B,0xF1,0x0F,0x83) }
+  [pscustomobject]@{ RVA=0x0128FF16L
+                     Bytes=[byte[]](0x48,0x8B,0xB0,0xE0,0x00,0x00,0x00,0x8B,0x47,0x14,0x8B,0x6E,0x20,0x44,0x8B,0xFD,0x8D,0x4D,0xFF,0x03,0x4E,0x24,0x83,0x3C,0x87,0x01,0x44,0x0F,0x46,0xF9,0x48,0x85,0xDB) }
+  [pscustomobject]@{ RVA=0x011B4619L
+                     Bytes=[byte[]](0x48,0x8B,0x0D,0xA0,0x58,0x08,0x02,0x8B,0xD6,0x48,0x8B,0x01,0x44,0x38,0xB9,0x1B,0x03,0x00,0x00,0x0F,0x84,0x6C,0x01,0x00,0x00,0xFF,0x90,0x30,0x01,0x00,0x00,0x0F,0x10,0x40,0x40) }
+  [pscustomobject]@{ RVA=0x01292963L
+                     Bytes=[byte[]](0xBB,0x04,0x00,0x00,0x00,0x48,0x8B,0x05,0x51,0x75,0xFA,0x01,0x0F,0x28,0x3D,0xEA,0x19,0x9B,0x00,0xB9,0x02,0x00,0x00,0x00,0x0F,0x28,0xEE,0x80,0xB8,0x1B,0x03,0x00,0x00,0x00,0x0F,0x29,0xB5,0xE0,0x07,0x00,0x00,0x0F,0x10,0x96,0x90,0x02,0x00,0x00,0x0F,0x44,0xD9,0x89,0x9D,0xA0,0x0B,0x00,0x00,0x0F,0x29,0x95,0xF0,0x07) }
+  [pscustomobject]@{ RVA=0x012886DAL
+                     Bytes=[byte[]](0x80,0xB8,0x1B,0x03,0x00,0x00,0x00,0x0F,0x84,0x32,0x03,0x00,0x00,0xF3,0x44,0x0F,0x10,0x05,0xF8,0x49,0x32,0x03) }
+  [pscustomobject]@{ RVA=0x01298B11L
+                     Bytes=[byte[]](0x48,0x8B,0x05,0xA8,0x13,0xFA,0x01,0xB9,0x03,0x00,0x00,0x00,0x44,0x38,0xA8,0x1B,0x03,0x00,0x00,0x0F,0x44,0xCF,0x44,0x3B,0xC1,0x73,0x79,0x41,0x8D,0x50,0x01,0x41,0x8B,0xC0,0x8B) }
+  [pscustomobject]@{ RVA=0x01299870L
+                     Bytes=[byte[]](0x48,0x8B,0x05,0x49,0x06,0xFA,0x01,0xB9,0x03,0x00,0x00,0x00,0x80,0xB8,0x1B,0x03,0x00,0x00,0x00,0x0F,0x44,0xCB,0x44,0x3B,0xE9,0x73,0x4D,0x41,0x8D,0x55,0x01,0x41,0x8B,0xCD,0x48) }
+  [pscustomobject]@{ RVA=0x0129DE80L
+                     Bytes=[byte[]](0x48,0x8B,0x05,0x39,0xC0,0xF9,0x01,0xB9,0x02,0x00,0x00,0x00,0x41,0xBE,0x04,0x00,0x00,0x00,0x80,0xB8,0x1B,0x03,0x00,0x00,0x00,0x44,0x0F,0x44,0xF1,0x44,0x0F,0x28,0x25,0x6B,0xC7,0xCB,0x00) }
+  [pscustomobject]@{ RVA=0x0127AAABL
+                     Bytes=[byte[]](0x74,0x0E,0xF3,0x0F,0x10,0x84,0x24,0x28,0x01,0x00,0x00,0xF3,0x0F,0x11,0x04,0x38,0x41,0x8B,0x46,0x14,0x41,0x8B,0x0C,0x86,0x8B,0x82,0x60,0x61,0x00,0x00,0x89,0x8C,0x24,0x28,0x01,0x00,0x00,0x49,0x3B,0xC0,0x74,0x0E,0xF3,0x0F,0x10,0x84,0x24,0x28) }
+  [pscustomobject]@{ RVA=0x0121C90AL
+                     Bytes=[byte[]](0x48,0x89,0x74,0x24,0x18,0x48,0x89,0x7C,0x24,0x20,0x41,0x56,0x48,0x83,0xEC,0x30,0x8B,0x41,0x14,0x41,0x8B,0xE9,0x45,0x8B,0xF0,0x8B,0xF2,0x48,0x8B,0xD9,0x8B,0x3C,0x81,0xE8,0x80,0x64,0x00,0x00,0x48,0x8B,0x8B,0xF8,0x16,0x00,0x00,0xE8,0x24,0x40,0xFC,0xFF,0x48,0x8B,0x8B,0x00,0x17,0x00,0x00) }
+  [pscustomobject]@{ RVA=0x01290220L
+                     Bytes=[byte[]](0x4C,0x89,0x4C,0x24,0x20,0x48,0x89,0x4C,0x24,0x08,0x55,0x53,0x56,0x57,0x41,0x54,0x41,0x56,0x41,0x57,0x48,0x81,0xEC,0xB0,0x01,0x00,0x00) }
+  [pscustomobject]@{ RVA=0x01291BC2L
+                     Bytes=[byte[]](0x0F,0x28,0xBD,0x30,0x01,0x00,0x00,0x44,0x0F,0x28,0x85,0x20,0x01,0x00,0x00,0x44,0x0F,0x28,0x8D,0x10,0x01,0x00,0x00,0x48,0x8D,0xA5,0x50,0x01,0x00,0x00,0x41,0x5F,0x41,0x5E,0x41,0x5C,0x5F,0x5E,0x5B,0x5D,0xC3) }
+  [pscustomobject]@{ RVA=0x0127E260L
+                     Bytes=[byte[]](0x4C,0x89,0x4C,0x24,0x20,0x4C,0x89,0x44,0x24,0x18,0x41,0x55,0x41,0x57) }
+  [pscustomobject]@{ RVA=0x0127FA73L
+                     Bytes=[byte[]](0x48,0x81,0xC4,0x78,0x02,0x00,0x00,0x41,0x5F,0x41,0x5D,0xC3) }
+  [pscustomobject]@{ RVA=0x011B892AL
+                     Bytes=[byte[]](0x48,0x8B,0x8C,0x24,0xC0,0x00,0x00,0x00,0x48,0x89,0x44,0x24,0x20,0xE8,0xE4,0x78,0x0D,0x00,0x48,0x8D,0x8C,0x24,0x60,0x02,0x00,0x00) }
+  [pscustomobject]@{ RVA=0x011B83CAL
+                     Bytes=[byte[]](0x48,0x8D,0x84,0x24,0xE0,0x01,0x00,0x00,0x48,0x89,0x5C,0x24,0x28,0x48,0x89,0x44,0x24,0x20,0xE8,0x7F,0x5E,0x0C,0x00,0x48,0x85,0xDB,0x74,0x45) }
+  [pscustomobject]@{ RVA=0x01290B90L
+                     Bytes=[byte[]](0x48,0x8B,0x8D,0xB0,0x01,0x00,0x00,0x48,0x8D,0x95,0xD0,0x01,0x00,0x00,0x89,0x44,0x24,0x28,0x4D,0x8B,0xC4,0x8B,0x41,0x04,0x44,0x8B,0x09,0x48,0x8B,0xCE,0x89,0x44,0x24,0x20,0xE8,0x69,0xF2,0xFF,0xFF,0x48,0x8B,0x9D,0xD0,0x01,0x00,0x00,0x48,0x8B,0xF8,0x48,0x8B,0x0D,0xD8,0x92,0xFA,0x01,0x4C,0x8D,0x0D,0xB1,0xF3,0xC6,0x00) }
+  [pscustomobject]@{ RVA=0x01291374L
+                     Bytes=[byte[]](0x48,0x8B,0x8D,0xB0,0x01,0x00,0x00,0x48,0x8D,0x95,0xD0,0x01,0x00,0x00,0x89,0x44,0x24,0x28,0x4D,0x8B,0xC4,0x8B,0x41,0x04,0x44,0x8B,0x09,0x48,0x8B,0xCE,0x89,0x44,0x24,0x20,0xE8,0x85,0xEA,0xFF,0xFF,0x48,0x8B,0x9D,0xD0,0x01,0x00,0x00,0x48,0x8B,0xF8,0x48,0x8B,0x85,0xB0,0x01,0x00,0x00,0x4C,0x8B,0x40,0x60,0x4D,0x85,0xC0) }
+  [pscustomobject]@{ RVA=0x012EB2A4L
+                     Bytes=[byte[]](0x80,0x00,0x00,0x00,0xBA,0x01,0x00,0x00,0x00,0x4C,0x8B,0x4F,0x20,0x48,0x03,0xC0,0x48,0x8B,0xCB,0x44,0x8D,0x42,0x14,0x0F,0xB7,0x74,0xC7,0x32,0x8B,0x43,0x14,0x0F,0xAF,0x34,0x83,0xE8,0x14,0x47,0xF3,0xFF,0x4C,0x8B,0x83,0x38,0x0F,0x00,0x00,0x33,0xC9,0x4D,0x85,0xC0,0x74,0x05,0x4D,0x8B,0x00,0xEB,0x03) }
+  [pscustomobject]@{ RVA=0x0128FE20L
+                     Bytes=[byte[]](0x48,0x89,0x5C,0x24,0x10,0x48,0x89,0x6C,0x24,0x18,0x56,0x57,0x41,0x54,0x41,0x56,0x41,0x57,0x48,0x81,0xEC,0xA0,0x00,0x00,0x00,0x48,0x8B,0x05,0x60,0xA0,0xFA,0x01) }
+)
+
+$COMMON_TWO_LAYER_CODE = @($VERIFIED_WNO_WRITERS) + @($VERIFIED_PRIMARY_DEPTH_CB)
+$BASELINE_CODE = @($COMMON_TWO_LAYER_CODE) + @($VERIFIED_VIEW_COUNT)
+$CORE_VIEW_EXTENSION = @($CAMERA_RECORDS_4) + @($CORE_DRAW_GATES_4) + @($OCCLUDER_STATE_4)
+$LEGACY_TESTKIT3_SITES = @($REFRACTION_DEPTH_ZERO) + @($CAMERA_STATE_4) + @($ASSAO_DEPTH_4) + @($SSR_FRUSTA_4) + @($CORE_VIEW_EXTENSION)
+$ALL_PROFILE_SITES = @($VERIFIED_VIEW_COUNT) + @($CULL_SCATTER_4) + @($LEGACY_TESTKIT3_SITES)
+$VERIFIED_CODE = @($BASELINE_CODE)
+
+# Every earlier experimental site remains stock-only. Selected v1.4 call blocks
+# are owned by the atomic hook transaction; every unselected block is a guard.
+$VERIFIED_GUARDS = @($ALL_PROFILE_SITES) + @($WATER_PASS_CALL) + @($SPRITE_COUNT_GUARD)
+$selectedRvas=@($VERIFIED_CODE | ForEach-Object { [Int64]$_.RVA })
+$VERIFIED_GUARDS=@($VERIFIED_GUARDS | Where-Object { $selectedRvas -notcontains [Int64]$_.RVA })
+foreach ($hookCall in $ALL_HOOK_SITES) {
+    if ($MODE_INFO.HookKinds -notcontains $hookCall.Kind) {
+        $VERIFIED_GUARDS += $hookCall
+    }
+}
+$profileRvas=@($VERIFIED_CODE | ForEach-Object { [Int64]$_.RVA }) +
+             @($VERIFIED_GUARDS | ForEach-Object { [Int64]$_.RVA }) +
+             @($ALL_HOOK_SITES | Where-Object { $MODE_INFO.HookKinds -contains $_.Kind } | ForEach-Object { [Int64]$_.RVA })
+if (@($profileRvas | Sort-Object -Unique).Count -ne $profileRvas.Count) {
+    throw "Internal v1.4 profile error: duplicate code/guard RVA." }
+foreach ($site in $VERIFIED_CODE) {
+    if ($site.Stock.Length -ne $site.Fix.Length) {
+        throw ("Internal v1.4 profile error: unequal patch length at 0x{0:X}." -f $site.RVA) } }
 
 # ===========================================================================
 #  PATTERN PATH - used only when the build is not the verified one
@@ -166,6 +556,22 @@ $SIGS = @(
   [pscustomobject]@{ Hit=12; Fix=[byte[]](0x48,0x85,0xE4,0x90,0x90,0x90,0x90)
     Pattern="74 16 49 8B 85 A0 41 01 00 41 8B CF 80 B8 1B 03 00 00 00 0F 45 CF"
     What="view count 4 - without this, geometry disappears" }
+)
+
+# The production transparency fix is located independently of the five v1.3
+# sites. The relative CALL displacement is wildcarded and decoded after the
+# whole surrounding sequence is proven unique. Both inner calls must resolve to
+# the same CopyRefractionDepth function or the untested build is rejected.
+$HOOK_SIGS = @(
+  [pscustomobject]@{ Name="DrawRefractiveAndTransparent camera call"; Kind="Outer"
+    Hit=0; Length=18; CallOffset=13; UnitOffset=0x000L; CounterOffset=0L
+    Pattern="48 8B 8C 24 C0 00 00 00 48 89 44 24 20 E8 ?? ?? ?? ?? 48 8D 8C 24 60 02 00 00" }
+  [pscustomobject]@{ Name="CopyRefractionDepth call A"; Kind="CopyA"
+    Hit=18; Length=21; CallOffset=16; UnitOffset=0x400L; CounterOffset=0x60L
+    Pattern="48 8B 8D B0 01 00 00 48 8D 95 D0 01 00 00 89 44 24 28 4D 8B C4 8B 41 04 44 8B 09 48 8B CE 89 44 24 20 E8 ?? ?? ?? ?? 48 8B 9D D0 01 00 00 48 8B F8 48 8B 0D ?? ?? ?? ?? 4C 8D 0D ?? ?? ?? ??" }
+  [pscustomobject]@{ Name="CopyRefractionDepth call B"; Kind="CopyB"
+    Hit=18; Length=21; CallOffset=16; UnitOffset=0x600L; CounterOffset=0x80L
+    Pattern="48 8B 8D B0 01 00 00 48 8D 95 D0 01 00 00 89 44 24 28 4D 8B C4 8B 41 04 44 8B 09 48 8B CE 89 44 24 20 E8 ?? ?? ?? ?? 48 8B 9D D0 01 00 00 48 8B F8 48 8B 85 B0 01 00 00 4C 8B 40 60 4D 85 C0" }
 )
 # Locator only, never patched.
 $SIG_DEVICE_PAT = "48 8B 0D ?? ?? ?? ?? 8B D6 48 8B 01 44 38 B9 1B 03 00 00 0F 84"
@@ -200,7 +606,8 @@ function WB { param([IntPtr]$h,[Int64]$a,[byte[]]$b)
     $w = [IntPtr]::Zero
     if (-not [HmFix]::WriteProcessMemory($h,[IntPtr]$a,$b,$b.Length,[ref]$w) -or $w.ToInt64() -ne $b.Length) {
         throw ("write failed at 0x{0:X}" -f $a) }
-    [HmFix]::FlushInstructionCache($h,[IntPtr]$a,[UIntPtr]::op_Explicit($b.Length)) | Out-Null }
+    if (-not [HmFix]::FlushInstructionCache($h,[IntPtr]$a,[UIntPtr]::op_Explicit($b.Length))) {
+        throw ("instruction-cache flush failed at 0x{0:X}" -f $a) } }
 function U8  { param($h,$a) (RB $h $a 1)[0] }
 function U16 { param($h,$a) [BitConverter]::ToUInt16((RB $h $a 2),0) }
 function U32 { param($h,$a) [BitConverter]::ToUInt32((RB $h $a 4),0) }
@@ -209,8 +616,399 @@ function W2B { param([UInt32[]]$W)
     $o = New-Object byte[] ($W.Length*4)
     for ($i=0;$i -lt $W.Length;$i++){ [Array]::Copy([BitConverter]::GetBytes($W[$i]),0,$o,$i*4,4) }
     return ,$o }
+function Hex-Bytes { param([string]$Text)
+    $tokens=@($Text -split '\s+' | Where-Object { $_ })
+    $out=New-Object byte[] $tokens.Count
+    for ($i=0;$i -lt $tokens.Count;$i++) { $out[$i]=[Convert]::ToByte($tokens[$i],16) }
+    return ,$out }
+function Join-Bytes { param([object[]]$Parts)
+    $length=0
+    foreach ($part in $Parts) { $length += ([byte[]]$part).Length }
+    $out=New-Object byte[] $length; $offset=0
+    foreach ($part in $Parts) {
+        $bytes=[byte[]]$part
+        [Array]::Copy($bytes,0,$out,$offset,$bytes.Length)
+        $offset += $bytes.Length }
+    return ,$out }
+function U64B { param([UInt64]$Value) return ,[BitConverter]::GetBytes($Value) }
+
+# v1.4's owner-aware wrapper blobs are built declaratively below. Labels
+# and RIP-relative data references are resolved after emission, avoiding hand-
+# maintained branch displacements while retaining deterministic byte images.
+function New-ByteBuilder { param([Int64]$Origin)
+    [pscustomobject]@{ Origin=$Origin; Bytes=New-Object 'System.Collections.Generic.List[byte]'; Labels=@{}; Branches=New-Object System.Collections.ArrayList } }
+function Emit-Bytes { param($Builder,[byte[]]$Bytes) foreach($x in $Bytes){$Builder.Bytes.Add($x)} }
+function Emit-Hex { param($Builder,[string]$Text) Emit-Bytes $Builder (Hex-Bytes $Text) }
+function Mark-Label { param($Builder,[string]$Name) if($Builder.Labels.ContainsKey($Name)){throw "duplicate wrapper label"};$Builder.Labels[$Name]=$Builder.Bytes.Count }
+function Emit-J8 { param($Builder,[byte]$Opcode,[string]$Target)
+    $Builder.Bytes.Add($Opcode);$p=$Builder.Bytes.Count;$Builder.Bytes.Add(0)
+    [void]$Builder.Branches.Add([pscustomobject]@{Position=$p;Size=1;Target=$Target}) }
+function Emit-J32 { param($Builder,[byte[]]$Opcode,[string]$Target)
+    Emit-Bytes $Builder $Opcode;$p=$Builder.Bytes.Count
+    1..4|ForEach-Object{$Builder.Bytes.Add(0)}
+    [void]$Builder.Branches.Add([pscustomobject]@{Position=$p;Size=4;Target=$Target}) }
+function Emit-Rip32 { param($Builder,[byte[]]$Prefix,[Int64]$Target) Emit-Bytes $Builder $Prefix;$next=$Builder.Origin+$Builder.Bytes.Count+4L;$d=$Target-$next;if($d -lt [Int32]::MinValue -or $d -gt [Int32]::MaxValue){throw "wrapper RIP target out of range"};Emit-Bytes $Builder ([BitConverter]::GetBytes([Int32]$d)) }
+function Finish-ByteBuilder { param($Builder)
+    foreach($j in $Builder.Branches){
+        if(-not $Builder.Labels.ContainsKey($j.Target)){throw "missing wrapper label"}
+        $d=[Int64]$Builder.Labels[$j.Target]-([Int64]$j.Position+[Int64]$j.Size)
+        if($j.Size -eq 1){
+            if($d -lt -128 -or $d -gt 127){throw "short wrapper branch out of range"}
+            $Builder.Bytes[$j.Position]=[byte]([sbyte]$d)
+        } else {
+            if($d -lt [Int32]::MinValue -or $d -gt [Int32]::MaxValue){throw "near wrapper branch out of range"}
+            $raw=[BitConverter]::GetBytes([Int32]$d)
+            for($i=0;$i -lt 4;$i++){$Builder.Bytes[$j.Position+$i]=$raw[$i]}
+        }
+    }
+    return ,$Builder.Bytes.ToArray() }
+
+function Build-OuterUnit { param([Int64]$Unit,[Int64]$Target,[bool]$ChangeCount)
+    $data=$Unit+0x1000L
+    $b=New-ByteBuilder $Unit
+
+    # Proven TestKit-6 ABI frame plus an owner scope. ownerCtx is the atomic
+    # gate; ownerTid is published only after acquisition. Local byte +5C uses
+    # bit 0 for ownership and bit 1 for a count change.
+    Emit-Hex $b 'F3 0F 1E FA'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x30L)
+    Emit-Hex $b @'
+48 8B 8C 24 C8 00 00 00
+48 89 44 24 28
+48 83 EC 78
+4C 8B 9C 24 A0 00 00 00 4C 89 5C 24 20
+4C 8B 9C 24 A8 00 00 00 4C 89 5C 24 28
+4C 8B 9C 24 B0 00 00 00 4C 89 5C 24 30
+4C 8B 9C 24 B8 00 00 00 4C 89 5C 24 38
+4C 8B 9C 24 C0 00 00 00 4C 89 5C 24 40
+4C 8B 9C 24 C8 00 00 00 4C 89 5C 24 48
+48 89 4C 24 50
+C7 44 24 5C 00 00 00 00
+'@
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x00L)
+    Emit-Hex $b '8B 41 14 89 44 24 58'
+    Emit-Rip32 $b (Hex-Bytes '3B 05') ($data+0x24L)
+    Emit-J8 $b 0x76 'max_top_ok'
+    Emit-Rip32 $b (Hex-Bytes '89 05') ($data+0x24L)
+    Mark-Label $b 'max_top_ok'
+    Emit-Hex $b '83 F8 04'
+    Emit-J8 $b 0x77 'bad_count'
+    Emit-Hex $b '44 8B 14 81'
+    Emit-Rip32 $b (Hex-Bytes '44 89 15') ($data+0x20L)
+    Emit-Hex $b '41 83 FA 04'
+    Emit-J8 $b 0x74 'count_four'
+    Emit-Hex $b '41 83 FA 01'
+    Emit-J32 $b (Hex-Bytes '0F 84') 'call_target'
+    Emit-Hex $b '41 83 FA 02'
+    Emit-J8 $b 0x74 'count_two'
+    Mark-Label $b 'bad_count'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x18L)
+    Emit-J32 $b (Hex-Bytes 'E9') 'call_target'
+
+    # Count two is ordinary only when no owner exists. A nonzero owner means
+    # re-entry or another thread observed the temporary shared state.
+    Mark-Label $b 'count_two'
+    Emit-Rip32 $b (Hex-Bytes '4C 8B 1D') ($data+0x40L)
+    Emit-Hex $b '4D 85 DB'
+    Emit-J8 $b 0x74 'call_target'
+    Emit-J32 $b (Hex-Bytes 'E9') 'owner_conflict'
+
+    Mark-Label $b 'count_four'
+    Emit-Rip32 $b (Hex-Bytes '4C 8B 1D') ($data+0x30L)
+    Emit-Hex $b '49 83 FB 01'
+    Emit-J8 $b 0x75 'owner_conflict'
+    Emit-Hex $b '33 C0'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 0F B1 0D') ($data+0x40L)
+    Emit-J8 $b 0x75 'owner_conflict'
+    Emit-Hex $b '65 4C 8B 14 25 48 00 00 00'
+    Emit-Rip32 $b (Hex-Bytes '4C 89 15') ($data+0x38L)
+    Emit-Hex $b '80 4C 24 5C 01'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x48L)
+    if($ChangeCount){
+        Emit-Hex $b '8B 44 24 58 C7 04 81 02 00 00 00 80 4C 24 5C 02'
+        Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x08L)
+    }
+    Emit-J32 $b (Hex-Bytes 'E9') 'call_target'
+
+    Mark-Label $b 'owner_conflict'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x28L)
+
+    Mark-Label $b 'call_target'
+    Emit-Hex $b '48 B8'
+    Emit-Bytes $b (U64B ([UInt64]$Target))
+    Emit-Hex $b 'FF D0 48 89 44 24 60'
+
+    Emit-Hex $b 'F6 44 24 5C 02'
+    Emit-J8 $b 0x74 'after_restore'
+    Emit-Hex $b '48 8B 4C 24 50 8B 44 24 58 83 F8 04'
+    Emit-J8 $b 0x77 'restore_bad'
+    Emit-Hex $b '83 3C 81 02'
+    Emit-J8 $b 0x75 'restore_bad'
+    Emit-Hex $b 'C7 04 81 04 00 00 00'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x10L)
+    Emit-Hex $b '39 41 14'
+    Emit-J8 $b 0x75 'restore_bad'
+    Emit-J8 $b 0xEB 'after_restore'
+    Mark-Label $b 'restore_bad'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x28L)
+
+    Mark-Label $b 'after_restore'
+    Emit-Hex $b 'F6 44 24 5C 01'
+    Emit-J8 $b 0x74 'finish'
+    Emit-Hex $b '48 8B 4C 24 50'
+    Emit-Rip32 $b (Hex-Bytes '4C 8B 1D') ($data+0x40L)
+    Emit-Hex $b '4C 3B D9'
+    Emit-J8 $b 0x75 'release_bad'
+    Emit-Hex $b '65 4C 8B 14 25 48 00 00 00'
+    Emit-Rip32 $b (Hex-Bytes '4C 3B 15') ($data+0x38L)
+    Emit-J8 $b 0x75 'release_bad'
+    Emit-Rip32 $b (Hex-Bytes '4C 8B 1D') ($data+0x30L)
+    Emit-Hex $b '49 83 FB 01'
+    Emit-J8 $b 0x75 'release_bad'
+    # Emit-Rip32 targets the end of its displacement field, so avoid a
+    # RIP-relative store with a trailing imm32 and clear through R10 instead.
+    Emit-Hex $b '45 33 D2'
+    Emit-Rip32 $b (Hex-Bytes '4C 89 15') ($data+0x38L)
+    Emit-Hex $b '48 8B C1'
+    Emit-Rip32 $b (Hex-Bytes 'F0 4C 0F B1 15') ($data+0x40L)
+    Emit-J8 $b 0x75 'release_bad'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x50L)
+    Emit-J8 $b 0xEB 'finish'
+    Mark-Label $b 'release_bad'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x28L)
+
+    Mark-Label $b 'finish'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 0D') ($data+0x30L)
+    Emit-Hex $b '48 8B 44 24 60 48 83 C4 78 C3'
+    Finish-ByteBuilder $b
+}
+
+function Emit-OwnerChecks { param($Builder,[Int64]$Data,[string]$NoOwnerLabel,[string]$MismatchLabel,[string]$ContextRegister)
+    Emit-Rip32 $Builder (Hex-Bytes '4C 8B 1D') ($Data+0x40L)
+    Emit-Hex $Builder '4D 85 DB'
+    Emit-J8 $Builder 0x74 $NoOwnerLabel
+    if($ContextRegister -eq 'rcx'){Emit-Hex $Builder '4C 3B D9'}
+    elseif($ContextRegister -eq 'rbx'){Emit-Hex $Builder '4C 3B DB'}
+    else{throw 'unsupported owner context register'}
+    Emit-J8 $Builder 0x75 $MismatchLabel
+    Emit-Hex $Builder '65 4C 8B 14 25 48 00 00 00'
+    Emit-Rip32 $Builder (Hex-Bytes '4C 3B 15') ($Data+0x38L)
+    Emit-J8 $Builder 0x75 $MismatchLabel
+}
+
+function Build-MeshUnit { param([Int64]$Unit)
+    # Mesh lives at cave+200; all wrappers deliberately share cave+1000 data.
+    $data=$Unit+0xE00L
+    $b=New-ByteBuilder $Unit
+    Emit-Hex $b @'
+F3 0F 1E FA
+8B 41 14 41 8B E9 45 8B F0 8B F2 48 8B D9 8B 3C 81
+'@
+    # This helper is global: absent or mismatched ownership remains stock.
+    Emit-OwnerChecks $b $data 'done' 'done' 'rbx'
+    Emit-Rip32 $b (Hex-Bytes '4C 8B 15') ($data+0x30L)
+    Emit-Hex $b '49 83 FA 01'
+    Emit-J8 $b 0x75 'bad'
+    Emit-Hex $b '83 FF 02'
+    Emit-J8 $b 0x75 'bad'
+    Emit-Hex $b 'BF 04 00 00 00'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x58L)
+    Emit-J8 $b 0xEB 'done'
+    Mark-Label $b 'bad'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x28L)
+    Mark-Label $b 'done'
+    Emit-Hex $b 'C3'
+    Finish-ByteBuilder $b
+}
+
+function Build-CopyUnit { param($Call,[Int64]$Unit,[Int64]$Target,[int]$FromCount,[int]$ToCount)
+    if(($FromCount -ne 4 -or $ToCount -ne 2) -and ($FromCount -ne 2 -or $ToCount -ne 4)){
+        throw 'unsupported CopyRefractionDepth count scope'}
+    [Int64]$counterOffset=[Int64]$Call.CounterOffset
+    if($counterOffset -ne 0x60L -and $counterOffset -ne 0x80L){throw 'invalid copy telemetry block'}
+    $data=$Unit+(0x1000L-[Int64]$Call.UnitOffset)
+    $b=New-ByteBuilder $Unit
+    Emit-Hex $b 'F3 0F 1E FA'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+$counterOffset+0x18L)
+
+    # Replay the common 21-byte setup/call block. The old caller's sixth
+    # argument moves from new [rsp+88] to the wrapper call's [rsp+28].
+    Emit-Hex $b @'
+4D 8B C4
+8B 41 04
+44 8B 09
+48 8B CE
+48 83 EC 58
+4C 8B 9C 24 88 00 00 00
+4C 89 5C 24 28
+89 44 24 20
+48 89 4C 24 38
+C7 44 24 34 00 00 00 00
+'@
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+$counterOffset)
+    Emit-Hex $b '8B 41 14 89 44 24 30'
+    Emit-Rip32 $b (Hex-Bytes '3B 05') ($data+0x24L)
+    Emit-J8 $b 0x76 'max_top_ok'
+    Emit-Rip32 $b (Hex-Bytes '89 05') ($data+0x24L)
+    Mark-Label $b 'max_top_ok'
+    Emit-Hex $b '83 F8 04'
+    Emit-J8 $b 0x77 'bad_count'
+    Emit-Hex $b '44 8B 1C 81'
+    Emit-Rip32 $b (Hex-Bytes '44 89 1D') ($data+0x20L)
+
+    # Preserve R11D (observed count). owner zero with current 1/2 is a stock
+    # desktop/unselected path; owner zero with current 4 is unexpected here.
+    Emit-Rip32 $b (Hex-Bytes '48 8B 05') ($data+0x40L)
+    Emit-Hex $b '48 85 C0'
+    Emit-J8 $b 0x74 'no_owner'
+    Emit-Hex $b '48 3B C1'
+    Emit-J8 $b 0x75 'owner_bad'
+    Emit-Hex $b '65 4C 8B 14 25 48 00 00 00'
+    Emit-Rip32 $b (Hex-Bytes '4C 3B 15') ($data+0x38L)
+    Emit-J8 $b 0x75 'owner_bad'
+    Emit-Rip32 $b (Hex-Bytes '48 8B 05') ($data+0x30L)
+    Emit-Hex $b '48 83 F8 01'
+    Emit-J8 $b 0x75 'owner_bad'
+    Emit-J8 $b 0xEB 'owner_ok'
+    Mark-Label $b 'no_owner'
+    Emit-Hex $b '41 83 FB 01'
+    Emit-J8 $b 0x74 'call_target'
+    Emit-Hex $b '41 83 FB 02'
+    Emit-J8 $b 0x74 'call_target'
+    Emit-J8 $b 0xEB 'owner_bad'
+    Mark-Label $b 'owner_ok'
+    Emit-Hex $b '8B 44 24 30'
+
+    Emit-Hex $b ('41 83 FB {0:X2}' -f $FromCount)
+    Emit-J8 $b 0x74 'change_count'
+    Emit-J8 $b 0xEB 'bad_count'
+    Mark-Label $b 'change_count'
+    Emit-Hex $b ('C7 04 81 {0:X2} 00 00 00 C6 44 24 34 01' -f $ToCount)
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+$counterOffset+0x08L)
+    Emit-J8 $b 0xEB 'call_target'
+    Mark-Label $b 'bad_count'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x18L)
+    Emit-J8 $b 0xEB 'call_target'
+    Mark-Label $b 'owner_bad'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x28L)
+
+    Mark-Label $b 'call_target'
+    Emit-Hex $b '48 B8'
+    Emit-Bytes $b (U64B ([UInt64]$Target))
+    Emit-Hex $b 'FF D0 48 89 44 24 40'
+    Emit-Hex $b '80 7C 24 34 01'
+    Emit-J8 $b 0x75 'finish'
+    Emit-Hex $b '48 8B 4C 24 38 8B 44 24 30 83 F8 04'
+    Emit-J8 $b 0x77 'restore_bad'
+    Emit-Hex $b ('83 3C 81 {0:X2}' -f $ToCount)
+    Emit-J8 $b 0x75 'restore_bad'
+    Emit-Hex $b ('C7 04 81 {0:X2} 00 00 00' -f $FromCount)
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+$counterOffset+0x10L)
+    Emit-Hex $b '39 41 14'
+    Emit-J8 $b 0x75 'restore_bad'
+    Emit-J8 $b 0xEB 'finish'
+    Mark-Label $b 'restore_bad'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 05') ($data+0x28L)
+
+    Mark-Label $b 'finish'
+    Emit-Rip32 $b (Hex-Bytes 'F0 48 FF 0D') ($data+$counterOffset+0x18L)
+    Emit-Hex $b '48 8B 44 24 40 48 83 C4 58 C3'
+    Finish-ByteBuilder $b
+}
+
+function Build-CallPatch { param($Call,[Int64]$Cave)
+    $length=$Call.Stock.Length
+    if ($length -lt 16 -or $length -gt 127) { throw "invalid hook patch-block length" }
+    $out=New-Object byte[] $length
+    for ($i=0;$i -lt $length;$i++) { $out[$i]=0x90 }
+    [byte[]]$head=0xFF,0x15,0x02,0x00,0x00,0x00,0xEB,[byte]($length-8)
+    [Array]::Copy($head,0,$out,0,$head.Length)
+    [Array]::Copy((U64B ([UInt64]($Cave+[Int64]$Call.UnitOffset))),0,$out,8,8)
+    return ,$out
+}
+
+function Allocate-HookMemory {
+    $allocated=[HmFix]::VirtualAllocEx($script:handle,[IntPtr]::Zero,[UIntPtr]::op_Explicit(0x2000),0x3000,0x04)
+    if ($allocated -eq [IntPtr]::Zero) { return 0L }
+    return $allocated.ToInt64()
+}
+function Suspend-GameThreads {
+    if ($script:unsafeCodeState) {
+        throw "the game is deliberately suspended after an unverified code rollback" }
+    if ($script:suspendedHandles.Count -gt 0 -and -not (Resume-GameThreads @())) {
+        throw "a previously suspended game thread could not be resumed" }
+    $held=@(); $seen=@{}
+    try {
+        for ($round=0;$round -lt 3;$round++) {
+            $added=0
+            $script:process.Refresh()
+            foreach ($thread in @($script:process.Threads)) {
+                $tid=[UInt32]$thread.Id
+                if ($seen.ContainsKey($tid)) { continue }
+                $handle=[HmFix]::OpenThread(0x0010000A,$false,$tid) # SYNCHRONIZE | SUSPEND_RESUME | GET_CONTEXT
+                if ($handle -eq [IntPtr]::Zero) {
+                    $openError=[Runtime.InteropServices.Marshal]::GetLastWin32Error()
+                    if ($openError -eq 87) { continue } # thread ended between snapshot and OpenThread
+                    throw ("could not open game thread {0} (Windows error {1})" -f $tid,$openError) }
+                $previous=[HmFix]::SuspendThread($handle)
+                if ($previous -eq [UInt32]::MaxValue) {
+                    $ended=([HmFix]::WaitForSingleObject($handle,0) -eq 0)
+                    [HmFix]::CloseHandle($handle) | Out-Null
+                    if ($ended) { continue }
+                    throw ("could not suspend game thread {0}" -f $tid) }
+                $held += [pscustomobject]@{ Id=$tid; Handle=$handle }
+                $seen[$tid]=$true; $added++ }
+            if ($added -eq 0) { return $held }
+            Start-Sleep -Milliseconds 5 }
+        $script:process.Refresh()
+        foreach ($thread in @($script:process.Threads)) {
+            if (-not $seen.ContainsKey([UInt32]$thread.Id)) { throw "game thread list did not become stable" } }
+        return $held
+    } catch {
+        Resume-GameThreads $held | Out-Null
+        throw
+    }
+}
+function Resume-GameThreads { param([object[]]$Held)
+    if ($script:unsafeCodeState) { return $false }
+    $ok=$true
+    $pending=@($script:suspendedHandles)+@($Held)
+    $script:suspendedHandles=@()
+    $seenHandles=@{}
+    foreach ($item in @($pending)) {
+        if ($null -eq $item -or $null -eq $item.Handle -or $item.Handle -isnot [IntPtr]) { $ok=$false; continue }
+        $key=$item.Handle.ToInt64().ToString("X")
+        if ($seenHandles.ContainsKey($key)) { continue }
+        $seenHandles[$key]=$true
+        $released=$false
+        for ($attempt=0;$attempt -lt 3 -and -not $released;$attempt++) {
+            try {
+                if ([HmFix]::ResumeThread($item.Handle) -ne [UInt32]::MaxValue) { $released=$true; break }
+                if ([HmFix]::WaitForSingleObject($item.Handle,0) -eq 0) { $released=$true; break }
+            } catch {}
+            if (-not $released) { Start-Sleep -Milliseconds 2 } }
+        if ($released) {
+            try { [HmFix]::CloseHandle($item.Handle) | Out-Null } catch { $ok=$false } }
+        else {
+            $script:suspendedHandles += $item
+            $ok=$false } }
+    return $ok
+}
+function Threads-AreOutsidePatchRanges { param([object[]]$Held,[object[]]$Ranges)
+    foreach ($item in @($Held)) {
+        if ($null -eq $item -or $null -eq $item.Handle -or $item.Handle -isnot [IntPtr]) {
+            throw "the suspended-thread list has an invalid shape" }
+        [UInt64]$rip=0
+        [Int32]$contextError=0
+        if (-not [HmFix]::TryGetThreadRip($item.Handle,[ref]$rip,[ref]$contextError)) {
+            throw ("could not verify the instruction pointer of game thread {0} (Windows error {1})" -f $item.Id,$contextError) }
+        foreach ($range in @($Ranges)) {
+            if ($rip -ge [UInt64]$range.Start -and $rip -lt [UInt64]$range.End) { return $false } }
+    }
+    return $true
+}
 function Log { param($t)
-    try { Add-Content -Path $LOG_PATH -Value ("{0}  {1}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"),$t) -Encoding UTF8 } catch {} }
+    try { Add-Content -Path $LOG_PATH -Value ("{0}  [{1}] {2}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"),$MODE_INFO.Short,$t) -Encoding UTF8 } catch {} }
 
 # --- PE parsing / pattern search (pattern path only) -----------------------
 function Read-PE { param([string]$path)
@@ -252,7 +1050,17 @@ function Find-Sig { param([byte[]]$hay,[string]$pat)
 $script:handle=[IntPtr]::Zero; $script:gamePid=0; $script:process=$null; $script:base=0L
 $script:mode=""            # verified | scanned
 $script:sites=@()
+$script:guardSites=@()       # verified-only preconditions; never written/restored
 $script:writtenSites=@()    # only sites this instance owns and may restore
+$script:hookDescriptors=@() # verified or uniquely pattern-located v1.4 call blocks
+$script:hookSites=@()       # dynamic indirect-CALL blocks owned by this instance
+$script:hookCave=0L; $script:hookPrepared=$false
+$script:lastHookLog=[DateTime]::MinValue
+$script:lastHookIntegrityCheck=[DateTime]::MinValue
+$script:hookProgress=@{}
+$script:lastPatchBusyLog=[DateTime]::MinValue
+$script:suspendedHandles=@()
+$script:unsafeCodeState=$false
 $script:devSlot=0L         # pattern path: RVA of the device pointer
 $script:wnoOff=$OFF_ACTIVE
 $script:patched=$false
@@ -265,8 +1073,89 @@ $script:deviceRestoreUncertain=$false
 $script:runtimeLoaded=$false; $script:lastRuntimeCheck=0L
 $script:lastWriteLog=[DateTime]::MinValue; $script:lastUi=""
 $script:fatal=""; $script:stopped=$false
+$script:renderSyncGate=New-Object object
+$script:rendererGuard=$null
+$script:guardWritePending=$false
+$script:guardReloadLatch=$false; $script:guardReloadSawNon3=$false
+$script:guardError=""; $script:lastGuardWriteLog=[DateTime]::MinValue
+
+function Stop-RendererGuard {
+    $guard=$script:rendererGuard
+    if ($null -eq $guard) { return $true }
+    try {
+        if (-not $guard.Stop(2000)) {
+            $script:fatal="The continuous renderer guard did not stop in time. Close HITMAN before continuing."
+            return $false }
+        Log ("renderer guard stopped; reads={0}, mismatches={1}, readFailures={2}" -f $guard.Reads,$guard.Mismatches,$guard.ReadFailures)
+        $script:rendererGuard=$null
+        $guard.Dispose()
+        return $true
+    } catch {
+        $script:fatal=("The continuous renderer guard could not be stopped safely: {0}. Close HITMAN." -f $_.Exception.Message)
+        return $false
+    }
+}
+
+function Invoke-RendererGuardSignal { param([RendererValueGuard]$Source)
+    try {
+        if ($null -eq $Source -or -not [Object]::ReferenceEquals($Source,$script:rendererGuard)) { return }
+        if ($script:handle -eq [IntPtr]::Zero -or $script:dev -eq 0 -or $Source.Device -ne $script:dev) { return }
+        if (-not (Game-IsAlive)) { return }
+        $current=Get-Dev
+        if ($current -ne $script:dev) { return }
+
+        # This is intentionally the complete v1.3 transaction, not a guard-
+        # specific write shortcut. It validates FOV/scale/mask, captures
+        # ownership, verifies both writes and rolls back failures.
+        $sync=Sync-RenderValues $script:dev
+        if ($sync.Wrote) {
+            try { $transition=U32 $script:handle ($script:dev+$OFF_TRANS) }
+            catch { $transition=-1 }
+            $script:guardWritePending=$true
+            if ($transition -eq 3) {
+                $script:guardReloadLatch=$true
+                $script:guardReloadSawNon3=$false
+            }
+            $now=Get-Date
+            if (($now-$script:lastGuardWriteLog).TotalSeconds -ge 1) {
+                Log ("1 ms renderer guard corrected values, transition={0}" -f $transition)
+                $script:lastGuardWriteLog=$now
+            }
+        }
+        if ($sync.Error) {
+            $script:guardError=$sync.Error
+            return
+        }
+    } catch {
+        if (Game-IsAlive) { $script:guardError=$_.Exception.Message }
+    } finally {
+        if ($null -ne $Source) { try { $Source.CompleteSignal() } catch {} }
+    }
+}
+
+function Ensure-RendererGuard { param([Int64]$Device)
+    if ($Device -eq 0 -or $script:handle -eq [IntPtr]::Zero) { return $false }
+    if ($null -ne $script:rendererGuard) {
+        if ($script:rendererGuard.Device -eq $Device -and $script:rendererGuard.IsRunning) { return $true }
+        if (-not (Stop-RendererGuard)) { return $false }
+    }
+    try {
+        [Action[RendererValueGuard]]$callback={ param([RendererValueGuard]$source) Invoke-RendererGuardSignal $source }
+        $guard=[RendererValueGuard]::new(
+            $script:handle,$Device,$OFF_SCALE,$OFF_MASK,(W2B $SCALE_FIX),$MASK_FIX,$form,$callback)
+        $script:rendererGuard=$guard
+        $guard.Start()
+        Log ("continuous 1 ms renderer guard started for device 0x{0:X}" -f $Device)
+        return $true
+    } catch {
+        $script:rendererGuard=$null
+        $script:guardError=("Continuous renderer guard could not start: {0}" -f $_.Exception.Message)
+        return $false
+    }
+}
 
 function Reset-DeviceState { param([bool]$OwnershipBecameUncertain=$false)
+    if (-not (Stop-RendererGuard)) { throw $script:fatal }
     if ($OwnershipBecameUncertain -and ($script:scaleTouched -or $script:maskTouched)) {
         $script:deviceRestoreUncertain=$true }
     $script:dev=0L; $script:lastTrans=-1L; $script:needRel=$false
@@ -275,7 +1164,10 @@ function Reset-DeviceState { param([bool]$OwnershipBecameUncertain=$false)
     $script:scaleStock=$null; $script:maskStock=$null
     $script:scaleTouched=$false; $script:maskTouched=$false
     $script:runtimeLoaded=$false; $script:lastRuntimeCheck=0L
-    $script:lastWriteLog=[DateTime]::MinValue }
+    $script:lastWriteLog=[DateTime]::MinValue
+    $script:guardWritePending=$false
+    $script:guardReloadLatch=$false; $script:guardReloadSawNon3=$false
+    $script:guardError=""; $script:lastGuardWriteLog=[DateTime]::MinValue }
 
 function Advance-Lifecycle {
     param([Int64]$LastTransition,[bool]$NeedReload,[UInt32]$Transition,[bool]$ValuesWritten)
@@ -289,10 +1181,34 @@ function Advance-Lifecycle {
         ResetStable=($changed -or $ValuesWritten) }
 }
 
+function Apply-GuardReloadLatch { param($Lifecycle,[UInt32]$Transition)
+    if (-not $script:guardReloadLatch) { return $Lifecycle }
+    if ($Transition -ne 3) {
+        $script:guardReloadSawNon3=$true
+        $Lifecycle.NeedReload=$true
+    } elseif ($script:guardReloadSawNon3) {
+        $script:guardReloadLatch=$false
+        $script:guardReloadSawNon3=$false
+        $Lifecycle.NeedReload=$false
+    } else {
+        $Lifecycle.NeedReload=$true
+    }
+    return $Lifecycle
+}
+
 function Detach {
+    Stop-RendererGuard | Out-Null
+    foreach ($item in @($script:suspendedHandles)) {
+        try { [HmFix]::CloseHandle($item.Handle) | Out-Null } catch {} }
+    $script:suspendedHandles=@()
     if ($script:handle -ne [IntPtr]::Zero) { [HmFix]::CloseHandle($script:handle) | Out-Null }
     $script:handle=[IntPtr]::Zero; $script:gamePid=0; $script:process=$null; $script:base=0L
-    $script:mode=""; $script:sites=@(); $script:writtenSites=@(); $script:devSlot=0L; $script:patched=$false
+    $script:mode=""; $script:sites=@(); $script:guardSites=@(); $script:writtenSites=@(); $script:hookDescriptors=@(); $script:hookSites=@()
+    $script:hookCave=0L; $script:hookPrepared=$false; $script:lastHookLog=[DateTime]::MinValue
+    $script:lastHookIntegrityCheck=[DateTime]::MinValue; $script:hookProgress=@{}
+    $script:lastPatchBusyLog=[DateTime]::MinValue
+    $script:unsafeCodeState=$false
+    $script:devSlot=0L; $script:patched=$false
     $script:dev=0L; $script:lastTrans=-1L; $script:needRel=$false
     $script:pendingValueWrite=$false
     $script:stableReady=0; $script:stableSince=0L
@@ -300,49 +1216,46 @@ function Detach {
     $script:scaleTouched=$false; $script:maskTouched=$false
     $script:deviceRestoreUncertain=$false
     $script:runtimeLoaded=$false; $script:lastRuntimeCheck=0L
-    $script:lastWriteLog=[DateTime]::MinValue; $script:lastUi="" }
+    $script:lastWriteLog=[DateTime]::MinValue; $script:lastUi=""
+    $script:guardWritePending=$false
+    $script:guardReloadLatch=$false; $script:guardReloadSawNon3=$false
+    $script:guardError=""; $script:lastGuardWriteLog=[DateTime]::MinValue }
 
-function Restore {
-    if ($script:handle -eq [IntPtr]::Zero) { return $true }
-    $ok=-not $script:deviceRestoreUncertain
-    if ($script:dev -ne 0) {
-        $deviceCurrent=$false
-        try { $deviceCurrent=((Get-Dev) -eq $script:dev) } catch {}
-        if (-not $deviceCurrent -and ($script:scaleTouched -or $script:maskTouched)) { $ok=$false }
-        if ($deviceCurrent -and $script:scaleTouched) {
-            $sb = $script:scaleStock; if ($null -eq $sb) { $sb = W2B $SCALE_STOCK }
-            try {
-                $cur=RB $script:handle ($script:dev+$OFF_SCALE) 16
-                if (Same $cur (W2B $SCALE_FIX)) {
-                    if ((Get-Dev) -ne $script:dev) { throw "device changed during restore" }
-                    WB $script:handle ($script:dev+$OFF_SCALE) $sb
-                    if (-not (Same (RB $script:handle ($script:dev+$OFF_SCALE) 16) $sb)) { $ok=$false } }
-                elseif (-not (Same $cur $sb)) { $ok=$false } }
-            catch { $ok=$false } }
-        if ($deviceCurrent -and $script:maskTouched) {
-            $mb = $script:maskStock; if ($null -eq $mb) { $mb = $MASK_STOCK }
-            try {
-                $cur=RB $script:handle ($script:dev+$OFF_MASK) 8
-                if (Same $cur $MASK_FIX) {
-                    if ((Get-Dev) -ne $script:dev) { throw "device changed during restore" }
-                    WB $script:handle ($script:dev+$OFF_MASK) $mb
-                    if (-not (Same (RB $script:handle ($script:dev+$OFF_MASK) 8) $mb)) { $ok=$false } }
-                elseif (-not (Same $cur $mb)) { $ok=$false } }
-            catch { $ok=$false } } }
-    foreach ($s in $script:writtenSites) {
+function Game-IsAlive {
+    if ($script:handle -eq [IntPtr]::Zero) { return $false }
+    try {
+        $wait=[HmFix]::WaitForSingleObject($script:handle,0)
+        if ($wait -eq 0) { return $false }       # WAIT_OBJECT_0: process exited
+        return $true                            # WAIT_TIMEOUT or failure: fail closed
+    } catch { return $true }
+}
+
+# A return from the wrapper intentionally lands in the dynamic call block.  It
+# is therefore unsafe to rewrite that block while HITMAN can still have a thread
+# at the call or inside the wrapper.  Unknown/unreadable bytes fail closed too.
+function Hook-PatchMayBeLive {
+    if (-not $MODE_INFO.UsesHook -or $script:hookSites.Count -eq 0) { return $false }
+    if ($script:patched) { return $true }
+    foreach ($site in $script:hookSites) {
         try {
-            $cur=RB $script:handle ($script:base+$s.RVA) $s.Fix.Length
-            if (Same $cur $s.Fix) {
-                WB $script:handle ($script:base+$s.RVA) $s.Stock
-                if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Stock.Length) $s.Stock)) { $ok=$false } }
-            elseif (-not (Same $cur $s.Stock)) { $ok=$false } }
-        catch { $ok=$false } }
-    Log $(if($ok){"restored"}else{"restore incomplete - close HITMAN"})
-    return $ok }
+            $cur=RB $script:handle ($script:base+$site.RVA) $site.Stock.Length
+            if (Same $cur $site.Fix) { return $true }
+            if (-not (Same $cur $site.Stock)) { return $true }
+        } catch { return $true }
+    }
+    return $false
+}
+
+function Changes-MayBeLive {
+    if ($script:patched -or $script:writtenSites.Count -gt 0 -or
+        $script:scaleTouched -or $script:maskTouched -or $script:deviceRestoreUncertain -or
+        $script:suspendedHandles.Count -gt 0 -or $script:unsafeCodeState) { return $true }
+    return (Hook-PatchMayBeLive)
+}
 
 # --- window ----------------------------------------------------------------
 $form=New-Object Windows.Forms.Form
-$form.Text="HitmanVRFoveationFix"
+$form.Text="HitmanVRFoveationFix v1.4"
 $form.ClientSize=New-Object Drawing.Size(520,318)
 $form.FormBorderStyle="FixedSingle"; $form.MaximizeBox=$false
 $form.StartPosition="CenterScreen"
@@ -350,7 +1263,7 @@ $form.Font=New-Object Drawing.Font("Segoe UI",9)
 
 $title=New-Object Windows.Forms.Label
 $title.Location=New-Object Drawing.Point(20,18); $title.Size=New-Object Drawing.Size(480,28)
-$title.Text="Edge-to-edge sharpness for HITMAN in VR"
+$title.Text=$MODE_INFO.Title
 $title.Font=New-Object Drawing.Font("Segoe UI",13,[Drawing.FontStyle]::Bold)
 $form.Controls.Add($title)
 
@@ -380,18 +1293,18 @@ $steps=New-Object Windows.Forms.Label
 $steps.Location=New-Object Drawing.Point(22,214); $steps.Size=New-Object Drawing.Size(478,34)
 $steps.Font=New-Object Drawing.Font("Segoe UI",9)
 $steps.ForeColor=[Drawing.Color]::FromArgb(90,90,90)
-$steps.Text="Leave this window open while you play. No game file is changed - closing HITMAN undoes the renderer changes."
+$steps.Text="Start this tool before HITMAN. Leave the window open while you play."
 $form.Controls.Add($steps)
 
 $btnStop=New-Object Windows.Forms.Button
 $btnStop.Location=New-Object Drawing.Point(22,252); $btnStop.Size=New-Object Drawing.Size(200,36)
-$btnStop.Text="Turn off"; $btnStop.Enabled=$false
+$btnStop.Text="Turn off and restore"; $btnStop.Enabled=$false
 $form.Controls.Add($btnStop)
 
 $link=New-Object Windows.Forms.LinkLabel
 $link.Location=New-Object Drawing.Point(240,260); $link.Size=New-Object Drawing.Size(260,22)
-$link.Text="v1.3 by RealChrizzl - project page"
-$link.LinkArea=New-Object Windows.Forms.LinkArea(22,12)
+$link.Text="v1.4 - project page"
+$link.LinkArea=New-Object Windows.Forms.LinkArea(0,4)
 $link.TextAlign="MiddleRight"
 $link.Add_LinkClicked({ Start-Process "https://github.com/RealChrizzl/hitman-vr-foveation-fix" })
 $form.Controls.Add($link)
@@ -407,52 +1320,124 @@ function Show-State { param($colour,$head,$body,$warn="")
         default { [Drawing.Color]::Gray } }
     $state.Text=$head; $detail.Text=$body; $note.Text=$warn }
 
-Show-State "grey" "Waiting for HITMAN" "Start the game whenever you like - including straight into VR. This tool does the rest."
+Show-State "grey" "Waiting for HITMAN" "Start HITMAN after this tool. It will apply the fix before VR starts."
 
 # --- attach ----------------------------------------------------------------
 function Try-Attach {
-    $procs=@(Get-Process -Name $ProcessName -ErrorAction SilentlyContinue)
+    $procs=@()
+    foreach ($candidate in @(Get-Process -Name $ProcessName -ErrorAction SilentlyContinue)) {
+        try { if (-not $candidate.HasExited) { $procs += $candidate } } catch {} }
     if ($procs.Count -eq 0) { return $false }
     if ($procs.Count -gt 1) { $script:fatal="More than one HITMAN process is running. Close them all and start the game once."; return $false }
     $p=$procs[0]
+    try { if ($p.HasExited) { return $false } } catch { return $false }
     try { $path=$p.MainModule.FileName; $b=$p.MainModule.BaseAddress.ToInt64() } catch { return $false }
 
-    $fs=[IO.File]::OpenRead($path)
-    try { $br=New-Object IO.BinaryReader($fs); $fs.Position=0x3C; $pe=$br.ReadInt32(); $fs.Position=$pe+8; $stamp=$br.ReadInt32() }
-    finally { $fs.Dispose() }
+    try { $peCheck=Read-PE $path }
+    catch { $script:fatal="Could not verify the game executable's code section."; return $false }
+    $stamp=$peCheck.Stamp
+    try { $exeHash=(Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash.ToUpperInvariant() }
+    catch { $script:fatal="Could not verify the game executable."; return $false }
 
-    $sites=@(); $mode=""; $slot=0L; $wno=0x31BL
+    $sites=@(); $guards=@(); $hooks=@(); $mode=""; $slot=0L; $wno=0x31BL
     if ($stamp -eq $VERIFIED_TIMESTAMP) {
+        if ($exeHash -ne $VERIFIED_SHA256) {
+            Log ("refused executable hash {0}" -f $exeHash)
+            $script:fatal="This executable has the verified build number but different code. Nothing was changed."
+            return $false }
+        foreach ($ctx in $VERIFIED_DIAGNOSTIC_CONTEXTS) {
+            $offset=[int64]$ctx.RVA-[int64]$peCheck.TextRVA
+            if ($offset -lt 0 -or ($offset+$ctx.Bytes.Length) -gt $peCheck.Text.Length) {
+                $script:fatal="A verified instruction context falls outside the code section. Nothing was changed."
+                return $false }
+            $actual=New-Object byte[] $ctx.Bytes.Length
+            [Array]::Copy($peCheck.Text,[int]$offset,$actual,0,$actual.Length)
+            if (-not (Same $actual $ctx.Bytes)) {
+                Log ("refused context mismatch at RVA 0x{0:X}" -f $ctx.RVA)
+                $script:fatal="A verified instruction context does not match the executable. Nothing was changed."
+                return $false } }
+
         $mode="verified"
         foreach ($c in $VERIFIED_CODE) {
-            $sites += [pscustomobject]@{ RVA=$c.RVA; Stock=$c.Stock; Fix=$c.Fix } }
+            $sites += [pscustomobject]@{ Name=$c.Name; RVA=$c.RVA; Stock=$c.Stock; Fix=$c.Fix } }
+        foreach ($g in $VERIFIED_GUARDS) {
+            $guards += [pscustomobject]@{ Name=$g.Name; RVA=$g.RVA; Stock=$g.Stock } }
+        $hooks=@($COPY_DEPTH_CALL_A,$COPY_DEPTH_CALL_B,$TRANSPARENT_PASS_CALL)
         $wno=$VERIFIED_WNO_OFF
     } else {
         $mode="scanned"
-        try { $pe2 = Read-PE $path } catch { $script:fatal="Could not read the game executable."; return $false }
-        foreach ($s in $SIGS) {
-            $h=@(Find-Sig $pe2.Text $s.Pattern)
-            if ($h.Count -ne 1) {
-                $script:fatal="The code for '" + $s.What + "' could not be located uniquely in this build. Nothing was changed. Please report this build on the project page."
+        foreach ($sig in $SIGS) {
+            $hits=@(Find-Sig $peCheck.Text $sig.Pattern)
+            if ($hits.Count -ne 1) {
+                $script:fatal="The code for '" + $sig.What + "' could not be located uniquely in this build. Nothing was changed."
                 return $false }
-            $stock=New-Object byte[] $s.Fix.Length
-            [Array]::Copy($pe2.Text,$h[0]+$s.Hit,$stock,0,$stock.Length)
-            $sites += [pscustomobject]@{ RVA=[int64]($pe2.TextRVA+$h[0]+$s.Hit); Stock=$stock; Fix=$s.Fix } }
-        $h=@(Find-Sig $pe2.Text $SIG_DEVICE_PAT)
-        if ($h.Count -ne 1) { $script:fatal="The VR device reference could not be located uniquely in this build. Nothing was changed."; return $false }
-        $at=$h[0]
-        $rel=[BitConverter]::ToInt32($pe2.Text,$at+$SIG_DEVICE_REL)
-        $slot=[int64]($pe2.TextRVA+$at+7+$rel)
-        $wno =[int64][BitConverter]::ToUInt32($pe2.Text,$at+$SIG_DEVICE_DSP)
-        if ($wno -le 0 -or $wno -gt 0x4000) { $script:fatal="Implausible device layout in this build. Nothing was changed."; return $false }
+            $stock=New-Object byte[] $sig.Fix.Length
+            [Array]::Copy($peCheck.Text,$hits[0]+$sig.Hit,$stock,0,$stock.Length)
+            $sites += [pscustomobject]@{ Name=$sig.What; RVA=[int64]($peCheck.TextRVA+$hits[0]+$sig.Hit); Stock=$stock; Fix=$sig.Fix } }
+
+        foreach ($sig in $HOOK_SIGS) {
+            $hits=@(Find-Sig $peCheck.Text $sig.Pattern)
+            if ($hits.Count -ne 1) {
+                $script:fatal="The v1.4 refraction code for '" + $sig.Name + "' could not be located uniquely. Nothing was changed."
+                return $false }
+            $siteOffset=[int]($hits[0]+$sig.Hit)
+            $stock=New-Object byte[] $sig.Length
+            [Array]::Copy($peCheck.Text,$siteOffset,$stock,0,$stock.Length)
+            if ($stock[$sig.CallOffset] -ne 0xE8) {
+                $script:fatal="A located v1.4 refraction call has an unexpected instruction shape. Nothing was changed."
+                return $false }
+            $rel=[BitConverter]::ToInt32($stock,$sig.CallOffset+1)
+            $rva=[int64]($peCheck.TextRVA+$siteOffset)
+            $target=[int64]($rva+$sig.CallOffset+5L+$rel)
+            if ($target -lt $peCheck.TextRVA -or $target -ge ($peCheck.TextRVA+$peCheck.Text.Length)) {
+                $script:fatal="A located v1.4 refraction target falls outside executable code. Nothing was changed."
+                return $false }
+            $hooks += [pscustomobject]@{
+                Name=$sig.Name; Kind=$sig.Kind; RVA=$rva; TargetRVA=$target
+                ContinuationRVA=[int64]($rva+$sig.Length); UnitOffset=[int64]$sig.UnitOffset
+                CounterOffset=[int64]$sig.CounterOffset; Stock=$stock }
+        }
+        $copyTargets=@($hooks | Where-Object {$_.Kind -like "Copy*"} | ForEach-Object {[int64]$_.TargetRVA} | Sort-Object -Unique)
+        if ($copyTargets.Count -ne 1) {
+            $script:fatal="The two located refraction-depth calls do not share one target. Nothing was changed."
+            return $false }
+
+        $hits=@(Find-Sig $peCheck.Text $SIG_DEVICE_PAT)
+        if ($hits.Count -ne 1) {
+            $script:fatal="The VR device reference could not be located uniquely in this build. Nothing was changed."
+            return $false }
+        $at=$hits[0]
+        $rel=[BitConverter]::ToInt32($peCheck.Text,$at+$SIG_DEVICE_REL)
+        $slot=[int64]($peCheck.TextRVA+$at+7+$rel)
+        $wno=[int64][BitConverter]::ToUInt32($peCheck.Text,$at+$SIG_DEVICE_DSP)
+        if ($wno -le 0 -or $wno -gt 0x4000) {
+            $script:fatal="Implausible device layout in this build. Nothing was changed."
+            return $false }
     }
 
     $hnd=[HmFix]::OpenProcess(0x1F0FFF,$false,$p.Id)
-    if ($hnd -eq [IntPtr]::Zero) { $script:fatal="Access denied. Close this tool and start it as administrator."; return $false }
+    if ($hnd -eq [IntPtr]::Zero) {
+        try { if ($p.HasExited) { return $false } } catch { return $false }
+        $script:fatal="Access denied. Close this tool and start it as administrator."
+        return $false }
+
+    if ($MODE_INFO.UsesHook) {
+        [UInt32]$shadowPolicy=0
+        if (-not [HmFix]::GetProcessMitigationPolicy($hnd,15,[ref]$shadowPolicy,[UIntPtr]::op_Explicit(4))) {
+            [HmFix]::CloseHandle($hnd) | Out-Null
+            $script:fatal="Windows' hardware shadow-stack state could not be verified. The v1.4 hook was not installed."
+            return $false }
+        if (($shadowPolicy -band 1) -ne 0) {
+            [HmFix]::CloseHandle($hnd) | Out-Null
+            $script:fatal="Hardware-enforced stack protection is active for HITMAN. This v1.4 hook is conservatively refused."
+            return $false } }
 
     $script:handle=$hnd; $script:gamePid=$p.Id; $script:process=$p; $script:base=$b
-    $script:mode=$mode; $script:sites=$sites; $script:devSlot=$slot; $script:wnoOff=$wno
-    Log ("attached pid {0}, build {1}, mode {2}" -f $p.Id,$stamp,$mode)
+    $script:mode=$mode; $script:sites=$sites; $script:guardSites=$guards; $script:hookDescriptors=$hooks
+    $script:devSlot=$slot; $script:wnoOff=$wno
+    Log ("attached pid {0}, build {1}, mode {2}, base sites {3}, guards {4}, v1.4 calls {5}" -f $p.Id,$stamp,$mode,$sites.Count,$guards.Count,$hooks.Count)
+    Log ("writes: " + ((@($sites | ForEach-Object { "{0}=0x{1:X}" -f $(if($_.Name){$_.Name}else{"site"}),$_.RVA })) -join ", "))
+    Log ("guards: " + ((@($guards | ForEach-Object { "{0}=0x{1:X}" -f $(if($_.Name){$_.Name}else{"site"}),$_.RVA })) -join ", "))
     return $true }
 
 # --- device access, mode aware ---------------------------------------------
@@ -484,11 +1469,17 @@ function Get-Dev {
     if (-not (Dev-Plausible $d)) { return 0L }
     return $d }
 
-# only true when we are CONFIDENT VR is already up; uncertainty means patch
-function VR-Running {
-    $d = Get-Dev
-    if ($d -le 0) { return $false }
-    try { return ((U8 $script:handle ($d+$OFF_ACTIVE)) -eq 1) } catch { return $false } }
+# 0 = safely not running, 1 = running, -1 = state could not be proven.
+function Get-VRStartState {
+    try { $d = Get-Dev } catch { return -1 }
+    if ($d -eq -1L) { return -1 }
+    if ($d -eq 0L) { return 0 }
+    try {
+        $active=U8 $script:handle ($d+$OFF_ACTIVE)
+        if ($active -eq 0) { return 0 }
+        if ($active -eq 1) { return 1 }
+        return -1
+    } catch { return -1 } }
 
 # Either backend is fine - the device layout is identical, verified on both.
 function VR-Runtime-Loaded {
@@ -504,7 +1495,7 @@ function VR-Runtime-Loaded {
 # In particular this runs before +0x319 becomes active.  OpenVR rebuilds the
 # shader/constant-buffer state during mission and save-game loads; changing these
 # fields only after that rebuild leaves the old centre mask cached on the GPU.
-function Sync-RenderValues { param([Int64]$d)
+function Sync-RenderValuesCore { param([Int64]$d)
     $result=[pscustomobject]@{ Initialized=$false; Fixed=$false; Wrote=$false; Error="" }
 
     $fb=RB $script:handle ($d+$OFF_FOV) 16
@@ -591,7 +1582,178 @@ function Sync-RenderValues { param([Int64]$d)
         return $result }
     return $result }
 
+function Sync-RenderValues { param([Int64]$d)
+    [Threading.Monitor]::Enter($script:renderSyncGate)
+    try { return (Sync-RenderValuesCore $d) }
+    finally { [Threading.Monitor]::Exit($script:renderSyncGate) }
+}
+
+function Prepare-HookCave {
+    if (-not $MODE_INFO.UsesHook) { return $true }
+    if ($script:hookPrepared) { return $true }
+    try {
+        $cave=Allocate-HookMemory
+        if ($cave -eq 0) { throw "the private v1.4 wrapper allocation failed" }
+        $dynamic=@()
+        foreach ($call in $script:hookDescriptors) {
+            if ([Int64]$call.ContinuationRVA -ne ([Int64]$call.RVA+[Int64]$call.Stock.Length)) {
+                throw ("{0} call block does not end at its verified continuation" -f $call.Kind) }
+            if($call.Kind -ne "Mesh") {
+                $originalCallOffset=if($call.Kind -eq "Outer"){13}else{16}
+                if ($call.Stock[$originalCallOffset] -ne 0xE8) { throw ("{0} original call opcode is missing" -f $call.Kind) }
+                $originalRel=[BitConverter]::ToInt32($call.Stock,$originalCallOffset+1)
+                $decodedTarget=[Int64]$call.RVA+$originalCallOffset+5L+$originalRel
+                if ($decodedTarget -ne [Int64]$call.TargetRVA) {
+                    throw ("{0} target RVA does not match the original direct call" -f $call.Kind) }
+            }
+            $unitAddress=$cave+[Int64]$call.UnitOffset
+            if($call.Kind -eq "Outer"){$wrapper=Build-OuterUnit $unitAddress ($script:base+[Int64]$call.TargetRVA) ([bool]$MODE_INFO.OuterChangesCount)}
+            elseif($call.Kind -eq "Mesh"){$wrapper=Build-MeshUnit $unitAddress}
+            else{$wrapper=Build-CopyUnit $call $unitAddress ($script:base+[Int64]$call.TargetRVA) ([int]$MODE_INFO.CopyFrom) ([int]$MODE_INFO.CopyTo)}
+            $expectedWrapperLength=
+                if($call.Kind -eq "Outer"){if([bool]$MODE_INFO.OuterChangesCount){498}else{474}}
+                elseif($call.Kind -eq "Mesh"){98}
+                else{311}
+            if ($wrapper.Length -ne $expectedWrapperLength -or ([Int64]$call.UnitOffset+$wrapper.Length) -gt 0x1000L) {
+                throw ("{0} wrapper shape changed unexpectedly" -f $call.Kind) }
+            WB $script:handle $unitAddress $wrapper
+            $fix=Build-CallPatch $call $cave
+            if ([BitConverter]::ToUInt64($fix,8) -ne [UInt64]$unitAddress) {
+                throw ("{0} call block does not point at its wrapper" -f $call.Kind) }
+            $dynamic += [pscustomobject]@{
+                Name=$call.Name; Kind=$call.Kind; RVA=[Int64]$call.RVA
+                Stock=[byte[]]$call.Stock; Fix=[byte[]]$fix
+                WrapperAddress=$unitAddress; Wrapper=[byte[]]$wrapper }
+        }
+        if ($dynamic.Count -ne $MODE_INFO.HookKinds.Count) { throw "not every selected pass wrapper was built" }
+        $magic=[Text.Encoding]::ASCII.GetBytes("HMFIX-V1.4-W")
+        WB $script:handle ($cave+0x1400L) $magic
+        [UInt32]$oldProtect=0
+        if (-not [HmFix]::VirtualProtectEx($script:handle,[IntPtr]$cave,[UIntPtr]::op_Explicit(0x1000),0x20,[ref]$oldProtect)) {
+            throw "could not make the verified hook page executable" }
+        if (-not [HmFix]::FlushInstructionCache($script:handle,[IntPtr]$cave,[UIntPtr]::op_Explicit(0x1000))) {
+            throw "could not flush the verified hook page" }
+        foreach ($site in $dynamic) {
+            if (-not (Same (RB $script:handle $site.WrapperAddress $site.Wrapper.Length) $site.Wrapper)) { throw "wrapper readback failed" }
+            if ($site.Fix.Length -ne $site.Stock.Length) { throw "invalid dynamic call-block length" } }
+        if (-not (Same (RB $script:handle ($cave+0x1400L) $magic.Length) $magic)) { throw "hook ownership marker readback failed" }
+        $script:hookCave=$cave; $script:hookSites=$dynamic; $script:hookPrepared=$true
+        Log ("v1.4 refraction cave prepared at 0x{0:X}; calls {1}" -f $cave,(($dynamic | ForEach-Object {$_.Kind}) -join ","))
+        return $true
+    } catch {
+        $script:fatal=("The v1.4 refraction hook could not be prepared safely: {0}. Nothing was hooked." -f $_.Exception.Message)
+        return $false }
+}
+
+function Read-HookTelemetry { param($Site)
+    if (-not $script:hookPrepared -or $script:hookCave -eq 0) { return $null }
+    $bytes=RB $script:handle ($script:hookCave+0x1000L) 0xA0
+    return [pscustomobject]@{
+        Kind=$Site.Kind
+        Calls=[BitConverter]::ToUInt64($bytes,0x00)
+        Changed=[BitConverter]::ToUInt64($bytes,0x08)
+        Restored=[BitConverter]::ToUInt64($bytes,0x10)
+        BadCount=[BitConverter]::ToUInt64($bytes,0x18)
+        LastOld=[BitConverter]::ToUInt32($bytes,0x20)
+        MaxTop=[BitConverter]::ToUInt32($bytes,0x24)
+        BadState=[BitConverter]::ToUInt64($bytes,0x28)
+        Active=[BitConverter]::ToUInt64($bytes,0x30)
+        OwnerTid=[BitConverter]::ToUInt64($bytes,0x38)
+        OwnerCtx=[BitConverter]::ToUInt64($bytes,0x40)
+        OwnerAcquired=[BitConverter]::ToUInt64($bytes,0x48)
+        OwnerReleased=[BitConverter]::ToUInt64($bytes,0x50)
+        MeshOverrides=[BitConverter]::ToUInt64($bytes,0x58)
+        CopyACalls=[BitConverter]::ToUInt64($bytes,0x60)
+        CopyAChanged=[BitConverter]::ToUInt64($bytes,0x68)
+        CopyARestored=[BitConverter]::ToUInt64($bytes,0x70)
+        CopyAActive=[BitConverter]::ToUInt64($bytes,0x78)
+        CopyBCalls=[BitConverter]::ToUInt64($bytes,0x80)
+        CopyBChanged=[BitConverter]::ToUInt64($bytes,0x88)
+        CopyBRestored=[BitConverter]::ToUInt64($bytes,0x90)
+        CopyBActive=[BitConverter]::ToUInt64($bytes,0x98) }
+}
+
+function Read-AllHookTelemetry {
+    if (-not $script:hookPrepared -or $script:hookCave -eq 0) { return $null }
+    $bytes=RB $script:handle ($script:hookCave+0x1000L) 0xA0
+    return [pscustomobject]@{
+        Calls=[BitConverter]::ToUInt64($bytes,0x00); Changed=[BitConverter]::ToUInt64($bytes,0x08)
+        Restored=[BitConverter]::ToUInt64($bytes,0x10); BadCount=[BitConverter]::ToUInt64($bytes,0x18)
+        LastOld=[BitConverter]::ToUInt32($bytes,0x20); MaxTop=[BitConverter]::ToUInt32($bytes,0x24)
+        BadState=[BitConverter]::ToUInt64($bytes,0x28); Active=[BitConverter]::ToUInt64($bytes,0x30)
+        OwnerTid=[BitConverter]::ToUInt64($bytes,0x38); OwnerCtx=[BitConverter]::ToUInt64($bytes,0x40)
+        OwnerAcquired=[BitConverter]::ToUInt64($bytes,0x48); OwnerReleased=[BitConverter]::ToUInt64($bytes,0x50)
+        MeshOverrides=[BitConverter]::ToUInt64($bytes,0x58)
+        CopyACalls=[BitConverter]::ToUInt64($bytes,0x60); CopyAChanged=[BitConverter]::ToUInt64($bytes,0x68)
+        CopyARestored=[BitConverter]::ToUInt64($bytes,0x70); CopyAActive=[BitConverter]::ToUInt64($bytes,0x78)
+        CopyBCalls=[BitConverter]::ToUInt64($bytes,0x80); CopyBChanged=[BitConverter]::ToUInt64($bytes,0x88)
+        CopyBRestored=[BitConverter]::ToUInt64($bytes,0x90); CopyBActive=[BitConverter]::ToUInt64($bytes,0x98) }
+}
+
+function Get-HookTelemetryState {
+    $result=[pscustomobject]@{ Ready=(-not $MODE_INFO.UsesHook); Error=""; Summary="" }
+    if (-not $MODE_INFO.UsesHook) { return $result }
+    $parts=@(); $allReady=$true; $now=Get-Date
+    try {
+        $checkIntegrity=(($now-$script:lastHookIntegrityCheck).TotalSeconds -ge 2)
+        foreach ($site in $script:hookSites) {
+            if ($checkIntegrity) {
+                if (-not (Same (RB $script:handle ($script:base+$site.RVA) $site.Fix.Length) $site.Fix)) {
+                    throw ("{0} call block no longer matches the installed v1.4 fix" -f $site.Kind) }
+                if (-not (Same (RB $script:handle $site.WrapperAddress $site.Wrapper.Length) $site.Wrapper)) {
+                    throw ("{0} wrapper code no longer matches its verified image" -f $site.Kind) } }
+        }
+        $t=Read-AllHookTelemetry
+        if ($null -eq $t) { throw "hook telemetry is unavailable" }
+        if ($t.BadCount -ne 0 -or $t.BadState -ne 0 -or $t.MaxTop -gt 4) {
+            throw ("a wrapper rejected an unexpected owner/count state (badCount={0}, badState={1}, maxTop={2})" -f $t.BadCount,$t.BadState,$t.MaxTop) }
+        $stableSample=$null
+        if ($t.Active -eq 0 -and $t.CopyAActive -eq 0 -and $t.CopyBActive -eq 0) {
+            $second=Read-AllHookTelemetry
+            if($null -ne $second -and $second.Active -eq 0 -and $second.CopyAActive -eq 0 -and $second.CopyBActive -eq 0 -and
+               $second.Calls -eq $t.Calls -and $second.Changed -eq $t.Changed -and $second.Restored -eq $t.Restored -and
+               $second.CopyACalls -eq $t.CopyACalls -and $second.CopyAChanged -eq $t.CopyAChanged -and $second.CopyARestored -eq $t.CopyARestored -and
+               $second.CopyBCalls -eq $t.CopyBCalls -and $second.CopyBChanged -eq $t.CopyBChanged -and $second.CopyBRestored -eq $t.CopyBRestored -and
+               $second.OwnerTid -eq $t.OwnerTid -and $second.OwnerCtx -eq $t.OwnerCtx){$stableSample=$second}
+        }
+        if ($null -ne $stableSample) {
+            if($t.OwnerTid -ne 0 -or $t.OwnerCtx -ne 0){throw "the transparent-pass owner marker stayed set"}
+            if($t.OwnerAcquired -ne $t.OwnerReleased){throw "transparent-pass owner acquisition was not balanced"}
+            if($t.Changed -ne $t.Restored -or $t.CopyAChanged -ne $t.CopyARestored -or $t.CopyBChanged -ne $t.CopyBRestored){throw "a local count change was not restored"}
+        }
+        if($t.OwnerAcquired -eq 0){$allReady=$false}
+        if($t.CopyAChanged -eq 0 -or $t.CopyBChanged -eq 0){$allReady=$false}
+        foreach($unitName in @("Outer","CopyA","CopyB")){
+            $isActive=if($unitName -eq "Outer"){$t.Active}elseif($unitName -eq "CopyA"){$t.CopyAActive}else{$t.CopyBActive}
+            $progressValue=if($unitName -eq "Outer"){$t.Calls+$t.Restored}elseif($unitName -eq "CopyA"){$t.CopyACalls+$t.CopyARestored}else{$t.CopyBCalls+$t.CopyBRestored}
+            $progress=$script:hookProgress[$unitName]
+            if($isActive -eq 0){$script:hookProgress.Remove($unitName)|Out-Null}
+            elseif($null -eq $progress -or $progress.Value -ne $progressValue){$script:hookProgress[$unitName]=[pscustomobject]@{Value=$progressValue;Since=$now}}
+            elseif(($now-$progress.Since).TotalSeconds -ge 10){throw ("{0} wrapper stayed active without progress for ten seconds" -f $unitName)}
+        }
+        $parts += ("outer calls={0}, owner={1}/{2}, changed={3}/{4}, mesh4={5}, copyA={6}/{7}/{8}, copyB={9}/{10}/{11}, active={12}/{13}/{14}" -f $t.Calls,$t.OwnerAcquired,$t.OwnerReleased,$t.Changed,$t.Restored,$t.MeshOverrides,$t.CopyACalls,$t.CopyAChanged,$t.CopyARestored,$t.CopyBCalls,$t.CopyBChanged,$t.CopyBRestored,$t.Active,$t.CopyAActive,$t.CopyBActive)
+        if ($checkIntegrity) {
+            foreach($s in $script:sites){if(-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Fix.Length) $s.Fix)){throw ("base fix changed at RVA 0x{0:X}" -f $s.RVA)}}
+            foreach($g in $script:guardSites){if(-not (Same (RB $script:handle ($script:base+$g.RVA) $g.Stock.Length) $g.Stock)){throw ("stock guard changed at RVA 0x{0:X}" -f $g.RVA)}}
+            $magic=[Text.Encoding]::ASCII.GetBytes("HMFIX-V1.4-W")
+            if (-not (Same (RB $script:handle ($script:hookCave+0x1400L) $magic.Length) $magic)) {
+                throw "the v1.4 wrapper ownership marker changed" }
+            $script:lastHookIntegrityCheck=$now }
+        $result.Ready=$allReady; $result.Summary=($parts -join "; ")
+        if (((Get-Date)-$script:lastHookLog).TotalSeconds -ge 5) {
+            Log ("pass telemetry: " + $result.Summary)
+            $script:lastHookLog=Get-Date }
+    } catch { $result.Error=$_.Exception.Message }
+    return $result
+}
+
 function Apply-Code {
+    foreach ($g in $script:guardSites) {
+        $cur = RB $script:handle ($script:base+$g.RVA) $g.Stock.Length
+        if (-not (Same $cur $g.Stock)) {
+            $script:fatal="A guarded renderer site is not in its original state. Close HITMAN and every fix window, then start v1.4 again."
+            return $false } }
+
     $allFix=$true; $allStock=$true
     foreach ($s in $script:sites) {
         $cur = RB $script:handle ($script:base+$s.RVA) $s.Fix.Length
@@ -604,40 +1766,283 @@ function Apply-Code {
         $script:fatal="The game code is not in its original state. Close HITMAN, start it again, then this tool."
         return $false }
 
-    if (VR-Running) {
+    $vrStartState=Get-VRStartState
+    if ($vrStartState -lt 0) {
+        $script:fatal="The pre-VR renderer state could not be proven safely. Close HITMAN and retry; nothing was changed."
+        return $false }
+    if ($vrStartState -eq 1) {
         $script:fatal="VR was already running when this tool attached. Close HITMAN, start this tool first, then the game."
         return $false }
 
-    $written=@()
+    if ($MODE_INFO.UsesHook) {
+        foreach ($call in $script:hookDescriptors) {
+            if (-not (Same (RB $script:handle ($script:base+$call.RVA) $call.Stock.Length) $call.Stock)) {
+                $script:fatal="A v1.4 refraction call is not in its original state. Close HITMAN and every fix window, then start v1.4 again."
+                return $false } }
+        if (-not (Prepare-HookCave)) { return $false } }
+
+    $held=@()
+    try { $held=@(Suspend-GameThreads) }
+    catch {
+        $script:fatal=("The game could not be paused safely for the atomic patch transaction: {0}. Nothing was changed." -f $_.Exception.Message)
+        return $false }
+
+    # Multi-instruction call blocks must never be replaced while a suspended
+    # thread is parked anywhere inside them.  The same conservative check is
+    # applied to the small v1.3 sites.  On a busy frame we simply resume and
+    # retry on a later timer tick without writing a byte.
     try {
+        $ranges=@()
+        foreach ($s in @($script:sites)+@($script:hookSites)) {
+            $start=[UInt64]($script:base+[Int64]$s.RVA)
+            $ranges += [pscustomobject]@{ Start=$start; End=[UInt64]($start+[UInt64]$s.Stock.Length) } }
+        foreach ($s in @($script:hookSites)) {
+            $start=[UInt64]$s.WrapperAddress
+            $ranges += [pscustomobject]@{ Start=$start; End=[UInt64]($start+[UInt64]$s.Wrapper.Length) } }
+        $telemetry=Read-AllHookTelemetry
+        if ($null -eq $telemetry -or $telemetry.Active -ne 0 -or $telemetry.CopyAActive -ne 0 -or $telemetry.CopyBActive -ne 0 -or
+            $telemetry.Calls -ne 0 -or $telemetry.OwnerTid -ne 0 -or $telemetry.OwnerCtx -ne 0 -or
+            $telemetry.CopyACalls -ne 0 -or $telemetry.CopyBCalls -ne 0 -or $telemetry.MeshOverrides -ne 0) {
+            throw "the fresh v1.4 wrapper data page did not have a clean zero state" }
+        $rangesClear=Threads-AreOutsidePatchRanges $held $ranges
+    }
+    catch {
+        $resumeOk=Resume-GameThreads $held; $held=@()
+        $script:fatal=("The patch was not installed because thread positions could not be verified safely: {0}. Nothing was changed." -f $_.Exception.Message)
+        if (-not $resumeOk) { $script:fatal += " One or more game threads could not be resumed; close HITMAN." }
+        return $false }
+    if (-not $rangesClear) {
+        $resumeOk=Resume-GameThreads $held; $held=@()
+        if (-not $resumeOk) {
+            $script:fatal="A game thread could not be resumed after a deferred patch attempt. Close HITMAN; nothing was written."
+            return $false }
+        if (((Get-Date)-$script:lastPatchBusyLog).TotalSeconds -ge 2) {
+            Log "patch transaction deferred because a render thread was inside a target instruction block"
+            $script:lastPatchBusyLog=Get-Date }
+        Start-Sleep -Milliseconds 50
+        return $false }
+
+    $written=@(); $hookWritten=@(); $applyOk=$false; $rollbackOk=$true; $failure=""
+    try {
+        # Recheck every precondition while all target threads are stopped.
+        $suspendedVrState=Get-VRStartState
+        if ($suspendedVrState -ne 0) {
+            if ($suspendedVrState -eq 1) { throw "VR became active before the suspended patch transaction" }
+            throw "the renderer state became uncertain before the suspended patch transaction" }
+        if ($script:mode -eq "verified") {
+            foreach ($ctx in $VERIFIED_DIAGNOSTIC_CONTEXTS) {
+                if (-not (Same (RB $script:handle ($script:base+$ctx.RVA) $ctx.Bytes.Length) $ctx.Bytes)) {
+                    throw ("a loaded verified code context changed at RVA 0x{0:X}" -f $ctx.RVA) } } }
+        foreach ($g in $script:guardSites) {
+            if (-not (Same (RB $script:handle ($script:base+$g.RVA) $g.Stock.Length) $g.Stock)) {
+                throw "a guarded renderer site changed before the suspended transaction" } }
+        foreach ($s in $script:sites) {
+            if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Stock.Length) $s.Stock)) {
+                throw "a base site changed before the suspended transaction" } }
+        foreach ($s in $script:hookSites) {
+            if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Stock.Length) $s.Stock)) {
+                throw "a selected pass call changed before the suspended transaction" } }
+
         foreach ($s in $script:sites) {
             # Include the site before attempting the write: WriteProcessMemory
             # can modify a prefix and still report a short/failed write.
             $written += $s
             WB $script:handle ($script:base+$s.RVA) $s.Fix }
-        Start-Sleep -Milliseconds 60
+        foreach ($s in $script:hookSites) {
+            $hookWritten += $s
+            WB $script:handle ($script:base+$s.RVA) $s.Fix }
         foreach ($s in $script:sites) {
             if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Fix.Length) $s.Fix)) {
                 throw "verification failed" } }
+        foreach ($s in $script:hookSites) {
+            if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Fix.Length) $s.Fix)) {
+                throw "hook verification failed" } }
+        foreach ($g in $script:guardSites) {
+            if (-not (Same (RB $script:handle ($script:base+$g.RVA) $g.Stock.Length) $g.Stock)) {
+                throw "a guarded renderer site changed during patch" } }
+        $applyOk=$true
     } catch {
-        # Never leave the game with only a subset of the five instructions
+        $failure=$_.Exception.Message
+        # Never leave the game with only a subset of this mode's instructions
         # patched.  Roll back every site written by this attempt immediately.
-        $rollbackOk=$true
+        for ($i=$hookWritten.Count-1;$i -ge 0;$i--) {
+            $s=$hookWritten[$i]
+            try {
+                WB $script:handle ($script:base+$s.RVA) $s.Stock
+                if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Stock.Length) $s.Stock)) { $rollbackOk=$false } }
+            catch { $rollbackOk=$false } }
         foreach ($s in $written) {
             try {
                 WB $script:handle ($script:base+$s.RVA) $s.Stock
                 if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Stock.Length) $s.Stock)) {
                     $rollbackOk=$false } }
             catch { $rollbackOk=$false } }
-        $script:writtenSites=@()
+    } finally {
+        if (-not $applyOk -and -not $rollbackOk) {
+            # A failed rollback can leave a partially rewritten instruction or
+            # call block.  Never let a target thread execute that uncertainty.
+            # Keep every handle suspended until the user terminates HITMAN;
+            # process exit is the only operation that discards this state.
+            $script:unsafeCodeState=$true
+            $script:suspendedHandles += @($held)
+            $held=@()
+        } elseif (-not (Resume-GameThreads $held)) {
+            $applyOk=$false; $rollbackOk=$false
+            if (-not $failure) { $failure="one or more game threads could not be resumed" } } }
+
+    if (-not $applyOk) {
+        $script:writtenSites=if($rollbackOk){@()}else{@($written)}
         if ($rollbackOk) {
-            $script:fatal="A patch did not stick. The partial change was rolled back; please restart HITMAN." }
+            $script:fatal=("A patch transaction failed ({0}) and was rolled back. Restart HITMAN before retrying." -f $failure) }
+        elseif ($script:unsafeCodeState) {
+            $script:fatal=("A patch transaction failed ({0}) and its rollback could not be verified. HITMAN remains deliberately suspended. End HITMAN in Task Manager; do not resume it." -f $failure) }
         else {
-            $script:fatal="A patch failed and could not be rolled back safely. Close HITMAN now; all changes disappear when the game exits." }
+            $script:fatal=("A patch transaction failed ({0}) and could not be made safe. Close HITMAN now; every change disappears when the game exits." -f $failure) }
         return $false }
     $script:writtenSites=$written
-    $script:patched=$true; Log "code patched"
+    $script:patched=$true
+    Log ("v1.4 code patched, base sites {0}, refraction calls {1}" -f $written.Count,$hookWritten.Count)
     return $true }
+
+# Restore renderer ownership and every code block while HITMAN is still live.
+# The dynamic CALL blocks can only be rewritten while all game threads are
+# suspended, no wrapper is active, and no RIP is inside a block or wrapper.
+# The executable cave itself remains allocated until process exit; this avoids
+# a stale-instruction or stale-return-address lifetime race.
+function Restore-RendererValues {
+    $ok=-not $script:deviceRestoreUncertain
+    if ($script:dev -eq 0) { return $ok }
+    $deviceCurrent=$false
+    try { $deviceCurrent=((Get-Dev) -eq $script:dev) } catch {}
+    if (-not $deviceCurrent -and ($script:scaleTouched -or $script:maskTouched)) { return $false }
+    if (-not $deviceCurrent) { return $ok }
+
+    if ($script:scaleTouched) {
+        $stock=$script:scaleStock; if ($null -eq $stock) { $stock=W2B $SCALE_STOCK }
+        try {
+            $cur=RB $script:handle ($script:dev+$OFF_SCALE) 16
+            if (Same $cur (W2B $SCALE_FIX)) {
+                if ((Get-Dev) -ne $script:dev) { throw "device changed during scale restore" }
+                WB $script:handle ($script:dev+$OFF_SCALE) $stock
+                if (-not (Same (RB $script:handle ($script:dev+$OFF_SCALE) 16) $stock)) { $ok=$false } }
+            elseif (-not (Same $cur $stock)) { $ok=$false } }
+        catch { $ok=$false }
+    }
+    if ($script:maskTouched) {
+        $stock=$script:maskStock; if ($null -eq $stock) { $stock=$MASK_STOCK }
+        try {
+            $cur=RB $script:handle ($script:dev+$OFF_MASK) 8
+            if (Same $cur $MASK_FIX) {
+                if ((Get-Dev) -ne $script:dev) { throw "device changed during mask restore" }
+                WB $script:handle ($script:dev+$OFF_MASK) $stock
+                if (-not (Same (RB $script:handle ($script:dev+$OFF_MASK) 8) $stock)) { $ok=$false } }
+            elseif (-not (Same $cur $stock)) { $ok=$false } }
+        catch { $ok=$false }
+    }
+    return $ok
+}
+
+function Restore {
+    if (-not (Stop-RendererGuard)) { return $false }
+    if ($script:handle -eq [IntPtr]::Zero) { return $true }
+    if (-not (Game-IsAlive)) { return $true }
+    if ($script:unsafeCodeState) { return $false }
+
+    [Threading.Monitor]::Enter($script:renderSyncGate)
+    try {
+        $held=@(); $safeSnapshot=$false
+        for ($attempt=0;$attempt -lt 20 -and -not $safeSnapshot;$attempt++) {
+            try { $held=@(Suspend-GameThreads) }
+            catch { $script:fatal=$_.Exception.Message; return $false }
+            try {
+                $ranges=@()
+                foreach ($s in @($script:writtenSites)+@($script:hookSites)) {
+                    $start=[UInt64]($script:base+[Int64]$s.RVA)
+                    $ranges += [pscustomobject]@{Start=$start;End=[UInt64]($start+[UInt64]$s.Stock.Length)} }
+                foreach ($s in @($script:hookSites)) {
+                    $start=[UInt64]$s.WrapperAddress
+                    $ranges += [pscustomobject]@{Start=$start;End=[UInt64]($start+[UInt64]$s.Wrapper.Length)} }
+                $telemetry=Read-AllHookTelemetry
+                $inactive=($null -eq $telemetry -or
+                    ($telemetry.Active -eq 0 -and $telemetry.CopyAActive -eq 0 -and $telemetry.CopyBActive -eq 0 -and
+                     $telemetry.OwnerTid -eq 0 -and $telemetry.OwnerCtx -eq 0))
+                $safeSnapshot=$inactive -and (Threads-AreOutsidePatchRanges $held $ranges)
+            } catch {
+                Resume-GameThreads $held | Out-Null; $held=@()
+                $script:fatal=("Live restoration could not verify game-thread positions: {0}" -f $_.Exception.Message)
+                return $false
+            }
+            if (-not $safeSnapshot) {
+                if (-not (Resume-GameThreads $held)) { return $false }
+                $held=@(); Start-Sleep -Milliseconds 50 }
+        }
+        if (-not $safeSnapshot) {
+            $script:fatal="The refraction pass stayed busy. Try Turn off again, or close HITMAN. Nothing was restored."
+            return $false
+        }
+
+        $restoreOrder=@()
+        for ($i=$script:hookSites.Count-1;$i -ge 0;$i--) { $restoreOrder += $script:hookSites[$i] }
+        $restoreOrder += @($script:writtenSites)
+        $restored=@(); $codeOk=$false; $rollbackOk=$true; $failure=""
+        try {
+            foreach ($s in $restoreOrder) {
+                $cur=RB $script:handle ($script:base+$s.RVA) $s.Fix.Length
+                if (-not (Same $cur $s.Fix)) {
+                    if (Same $cur $s.Stock) { continue }
+                    throw ("foreign bytes at RVA 0x{0:X}" -f $s.RVA) }
+                $restored += $s
+                WB $script:handle ($script:base+$s.RVA) $s.Stock
+                if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Stock.Length) $s.Stock)) {
+                    throw ("restore verification failed at RVA 0x{0:X}" -f $s.RVA) }
+            }
+            $codeOk=$true
+        } catch {
+            $failure=$_.Exception.Message
+            for ($i=$restored.Count-1;$i -ge 0;$i--) {
+                $s=$restored[$i]
+                try {
+                    WB $script:handle ($script:base+$s.RVA) $s.Fix
+                    if (-not (Same (RB $script:handle ($script:base+$s.RVA) $s.Fix.Length) $s.Fix)) { $rollbackOk=$false } }
+                catch { $rollbackOk=$false }
+            }
+        }
+
+        if (-not $codeOk) {
+            if (-not $rollbackOk) {
+                $script:unsafeCodeState=$true
+                $script:suspendedHandles += @($held); $held=@()
+                $script:fatal=("Live restoration failed ({0}) and rollback was not verifiable. HITMAN remains suspended. End it in Task Manager; do not resume it." -f $failure)
+            } else {
+                Resume-GameThreads $held | Out-Null; $held=@()
+                $script:fatal=("Live restoration failed ({0}) and was rolled back safely. Close HITMAN or try again." -f $failure)
+            }
+            return $false
+        }
+
+        $valuesOk=Restore-RendererValues
+        $resumeOk=Resume-GameThreads $held; $held=@()
+        if (-not $resumeOk) {
+            $script:fatal="The fix was restored, but one or more HITMAN threads could not be resumed. Close HITMAN."
+            return $false }
+
+        $script:patched=$false; $script:writtenSites=@()
+        if ($valuesOk) {
+            $script:scaleTouched=$false; $script:maskTouched=$false
+            $script:scaleStock=$null; $script:maskStock=$null
+            $script:deviceRestoreUncertain=$false
+            Log "restored"
+            return $true
+        }
+        $script:fatal="Code was restored, but a renderer value could not be restored safely. Closing HITMAN always discards it."
+        Log "restore incomplete - close HITMAN"
+        return $false
+    } finally {
+        if ($held.Count -gt 0 -and -not $script:unsafeCodeState) {
+            Resume-GameThreads $held | Out-Null }
+        [Threading.Monitor]::Exit($script:renderSyncGate)
+    }
+}
 
 # --- main loop -------------------------------------------------------------
 $timer=New-Object Windows.Forms.Timer
@@ -647,12 +2052,20 @@ $timer.Add_Tick({
         if ($script:stopped) { return }
 
         if ($script:handle -ne [IntPtr]::Zero) {
-            $gameClosed=$false
-            try { $gameClosed=($null -eq $script:process -or $script:process.HasExited) } catch { $gameClosed=$true }
+            $gameClosed=(-not (Game-IsAlive))
             if ($gameClosed) {
                 Log "game closed"; Detach; $script:fatal=""
-                Show-State "grey" "Waiting for HITMAN" "The game was closed. Start it again and this tool will patch it once more."
+                Show-State "grey" "Waiting for HITMAN" "The game was closed. Start it again and v1.4 will apply automatically."
                 $btnStop.Enabled=$false; return } }
+
+        if ($script:suspendedHandles.Count -gt 0) {
+            if ($script:unsafeCodeState) {
+                Show-State "red" "End HITMAN in Task Manager" "A failed code rollback could not be verified. HITMAN is deliberately kept suspended so the uncertain instruction can never execute. Force-close the game process; do not resume it."
+                return }
+            if (Resume-GameThreads @()) { Log "previously suspended game threads were resumed on retry" }
+            else {
+                Show-State "red" "Close HITMAN" "One or more game threads could not be resumed after three retries. End HITMAN from Task Manager; no further write will be attempted."
+                return } }
 
         if ($script:fatal) { Show-State "red" "Not active" $script:fatal; return }
 
@@ -661,13 +2074,26 @@ $timer.Add_Tick({
 
         $warn=""
         if ($script:mode -eq "scanned") {
-            $warn="Untested build - the code was located by pattern. Please check the image looks right." }
-        $ready="The game is patched. Put on your headset and start VR as usual, then load a mission."
+            $warn="Untested build - every v1.3 and v1.4 code pattern was unique, but please check the image carefully." }
+        $ready="v1.4 is patched. Put on your headset, start VR as usual, then load a mission."
 
         if (-not $script:patched) {
             if (-not (Apply-Code)) { return }
             $btnStop.Enabled=$true
             Show-State "amber" "Ready - start VR" $ready $warn
+            return }
+
+        $hookState=Get-HookTelemetryState
+        if ($hookState.Error) {
+            Stop-RendererGuard | Out-Null
+            $script:fatal=("The pass-local safety monitor detected an unexpected state: {0}. Close HITMAN now; do not continue this run." -f $hookState.Error)
+            Show-State "red" "Stop this run" $script:fatal $warn
+            return }
+
+        if ($script:guardError) {
+            Stop-RendererGuard | Out-Null
+            $script:fatal=("The continuous renderer guard stopped after a validated sync error: {0}" -f $script:guardError)
+            Show-State "red" "Renderer guard stopped" $script:fatal $warn
             return }
 
         $d = Get-Dev
@@ -683,7 +2109,13 @@ $timer.Add_Tick({
         if ($d -ne $script:dev) {
             if ($script:dev -ne 0) { Reset-DeviceState $true } else { Reset-DeviceState }
             $script:dev=$d
-            Log ("VR device found at 0x{0:X}" -f $d) }
+            $backend="unknown"
+            try {
+                $vt=I64 $script:handle $d
+                if ($vt -eq ($script:base+$OCULUS_VTABLE_RVA)) { $backend="Oculus" }
+                elseif ($vt -eq ($script:base+$OPENVR_VTABLE_RVA)) { $backend="SteamVR/OpenVR" } }
+            catch {}
+            Log ("VR device found at 0x{0:X}, backend {1}" -f $d,$backend) }
 
         $active=U8  $script:handle ($d+$OFF_ACTIVE)
         $wno   =U8  $script:handle ($d+$script:wnoOff)
@@ -714,6 +2146,8 @@ $timer.Add_Tick({
             return }
 
         $sync=Sync-RenderValues $d
+        if (-not $sync.Error -and $sync.Initialized -and $sync.Fixed) {
+            Ensure-RendererGuard $d | Out-Null }
         if ($sync.Wrote) {
             $script:pendingValueWrite=$true
             # Close the read/write race: classify the write using a fresh state
@@ -732,7 +2166,16 @@ $timer.Add_Tick({
             Show-State "red" "Not active" "VR started before the patch could take effect. Close HITMAN, start this tool first, then the game."
             return }
 
+        if ($script:guardWritePending) {
+            $script:pendingValueWrite=$true
+            $script:guardWritePending=$false }
+
         $life=Advance-Lifecycle $script:lastTrans $script:needRel $trans $script:pendingValueWrite
+
+        # A guard repair classified at transition 3 must survive the gap to the
+        # 15 ms lifecycle sample. Keep it latched through the following non-3
+        # rebuild phase and clear it only once that cycle reaches transition 3.
+        $life=Apply-GuardReloadLatch $life $trans
         if ($life.TransitionChanged) {
             Log ("transition {0} -> {1}" -f $script:lastTrans,$trans) }
         $script:lastTrans=$life.LastTransition
@@ -765,6 +2208,11 @@ $timer.Add_Tick({
             Show-State "amber" "Waiting for a mission" "VR is running in two-layer mode. Load a mission and the fix becomes active." $warn
             return }
 
+        if (-not $hookState.Ready) {
+            $script:stableReady=0; $script:stableSince=0L
+            Show-State "amber" "Waiting for the scene renderer" "The refraction wrapper and guard are installed. Load a mission so the glass/water pass runs once." $warn
+            return }
+
         if ($script:needRel) {
             $script:stableReady=0; $script:stableSince=0L
             Show-State "amber" "Reload this mission once" "The fix is set, but this mission was already running when it was applied. Reload it once and the image will be sharp everywhere." $warn
@@ -776,23 +2224,45 @@ $timer.Add_Tick({
             if ($script:stableReady -lt 3 -or $stableMs -lt 250) {
                 Show-State "amber" "Finishing the mission load" "The render values are correct. Waiting briefly to make sure they remain stable." $warn
             } else {
-                Show-State "green" "Active" ("Sharp from edge to edge. Rendering {0} x {1} per eye in two layers instead of four." -f $w,$h) $warn } }
+                Show-State "green" "Active" ("Sharp from edge to edge at {0} x {1} per eye. Glass, water and refraction use the corrected two-eye copy path; the 1 ms save-load guard is running." -f $w,$h) $warn } }
     } catch {
         Show-State "red" "Something went wrong" ($_.Exception.Message + "  Close HITMAN and try again.") }
 })
 $timer.Start()
 
 $btnStop.Add_Click({
-    $restored=Restore; Detach
+    if ($script:unsafeCodeState -and (Game-IsAlive)) {
+        Show-State "red" "End HITMAN in Task Manager" "The failed rollback remains deliberately suspended. Force-close the HITMAN process; do not resume it." $MODE_INFO.Warning
+        return }
+    $restored=Restore
+    if (-not $restored) {
+        if ($script:unsafeCodeState) {
+            Show-State "red" "End HITMAN in Task Manager" $script:fatal
+        } else {
+            Show-State "amber" "Close HITMAN or retry" $script:fatal }
+        return }
+    Detach
     $script:stopped=$true; $script:fatal=""
     $btnStop.Enabled=$false
-    if ($restored) {
-        Show-State "grey" "Turned off" "Everything this tool changed was restored. Close and reopen it to use the fix again." }
-    else {
-        Show-State "amber" "Close HITMAN" "A live value could not be restored safely. Closing the game always discards every in-memory change." } })
+    Show-State "grey" "Turned off" "Everything owned by v1.4 was restored. Close and reopen this tool to use the fix again." })
 
-$form.Add_FormClosing({
-    $timer.Stop(); Restore | Out-Null
+$form.Add_FormClosing({ param($sender,$eventArgs)
+    if ($script:unsafeCodeState -and (Game-IsAlive)) {
+        $eventArgs.Cancel=$true
+        Show-State "red" "End HITMAN in Task Manager" "The failed rollback remains deliberately suspended. Force-close the HITMAN process; do not resume it." $MODE_INFO.Warning
+        Log "window close deferred while an unsafe rollback state remains suspended"
+        return }
+    $timer.Stop()
+    if ((Game-IsAlive) -and (Changes-MayBeLive) -and -not (Restore)) {
+        $eventArgs.Cancel=$true
+        $timer.Start()
+        if ($script:unsafeCodeState) {
+            Show-State "red" "End HITMAN in Task Manager" $script:fatal
+        } else {
+            Show-State "amber" "Close HITMAN or retry" $script:fatal }
+        Log "window close deferred because live restoration was incomplete"
+        return }
+    Detach
     if ($script:handle -ne [IntPtr]::Zero) { [HmFix]::CloseHandle($script:handle) | Out-Null }
     if ($script:mutexOwned) {
         try { $script:instanceMutex.ReleaseMutex() } catch {}

--- a/README.md
+++ b/README.md
@@ -2,33 +2,40 @@
 
 **Edge-to-edge sharpness for HITMAN World of Assassination in PC VR.**
 
-If everything outside the middle of your view looks like mush, this fixes it.
+If the middle of the image looks sharp and everything around it turns to mush, this fixes that.
 
-The effect is most obvious on pancake-lens headsets — **Quest 3 and Quest Pro** —
-because their optics are sharp all the way to the edge, so the software blur is the
-only thing left blurring the picture. On Fresnel headsets (Quest 2, Quest 3S, Rift S)
-it works too, the gain is just smaller because the lenses already soften the
-periphery.
+Windows **v1.4** also fixes the eye-to-eye mismatch that could make glass, flowing water, bottles and some lights look different in each eye.
 
-PC VR only, not the standalone version. Both of the game's VR backends are supported
-and verified: **Oculus** (Quest via Link or Air Link, Rift S) and **SteamVR / OpenVR**
-(including headsets connected through Steam Link, Virtual Desktop or their native
-PC streaming software).
+There was one more wrinkle: simply reducing the renderer to two views also caused angle-dependent geometry pop-in around glass. v1.4 avoids that by keeping the normal four-view renderer for geometry and visibility, while using only the two physical eye views for the two `CopyRefractionDepth` calls.
+
+It also has a small renderer guard for the brief save-load window where the game could restore the old values and bring the black foveation circles back.
+
+The difference is easiest to see on pancake-lens headsets such as **Quest 3 and Quest Pro**. Their lenses stay sharp much farther towards the edges, so when the edge is blurry, you are mostly looking at the game's software blur.
+
+It works on Fresnel headsets too — Quest 2, Quest 3S, Rift S — but the difference is harder to see because the lenses already blur the edges.
+
+PC VR only. This does **not** work with the standalone version.
+
+Both VR backends are supported and tested:
+
+- **Oculus** — Quest via Link or Air Link, Rift S
+- **SteamVR / OpenVR** — including headsets connected through Steam Link, Virtual Desktop or their normal PC streaming software
 
 ---
 
 ## See the difference
 
-Both crops are from the **outer part of the view**, taken at the same spot, shown at
-original resolution. This is what your eyes get whenever you are not staring dead
-ahead — which is most of the time.
+Both crops come from the **outer part of the view**, from the same spot and at original resolution.
+
+This is the part of the image you are looking through whenever you move your eyes away from dead centre. Which, unsurprisingly, happens quite a lot.
 
 ![Before and after, left side of the view](screenshots/comparison-left.png)
 
 ![Before and after, right side of the view](screenshots/comparison-right.png)
 
-Look at the wall texture, the ivy, the paving stones, the dappled shadows — and the
-pictograms on the bins. Same scene, same settings, same headset.
+Look at the wall texture, ivy, paving stones, dappled shadows and the pictograms on the bins.
+
+Same scene. Same settings. Same headset.
 
 ---
 
@@ -36,158 +43,265 @@ pictograms on the bins. Same scene, same settings, same headset.
 
 ### Windows
 
-1. Download the two files: `HitmanVRFoveationFix.ps1` and `HitmanVRFoveationFix.bat`
-   — keep them in the same folder
-2. Double-click **`HitmanVRFoveationFix.bat`** and allow the administrator prompt
+1. Download `HitmanVRFoveationFix.ps1` and `HitmanVRFoveationFix.bat`
+   — keep both files in the same folder
+2. Double-click **`HitmanVRFoveationFix.bat`** and accept the administrator prompt
 3. Start HITMAN however you normally do, including straight into VR
 4. Play
 
 Leave the small window open while you play.
 
-The window tells you what is going on: grey while it waits for the game,
-amber while VR or a mission is still loading, **green when the fix is active**. If
-something is wrong it turns red and says what.
+It tells you what the tool is doing:
+
+- grey: waiting for HITMAN
+- amber: VR or the mission is still loading
+- **green: the fix is active**
+- red: something went wrong, and the window tells you what
+
+The normal UI and lifecycle loop runs every 15 ms.
+
+Once the renderer has been fully validated, v1.4 starts a separate sleeping guard which checks only two tiny pieces of renderer state: the 16-byte scale field and the 8-byte mask field, roughly once per millisecond.
+
+If those bytes are already correct, it does nothing.
+
+If they change, the guard hands control back to the same full validation, ownership, write, verification and rollback path used by the normal loop. There is no second "just write it and hope" code path hiding underneath.
 
 ### Why a .bat and not an .exe
 
-Reading another program's memory is exactly what a debugger does — and also what
-malware does. Packed PowerShell executables get flagged by antivirus software as a
-category, regardless of what is inside them, so shipping one would mean asking you to
-click past a virus warning. A plain script you can read is more honest.
+Reading another program's memory is what debuggers do.
 
-The `.bat` is one line. Open it in Notepad if you like; it does nothing but start the
-script next to it.
+It is also what malware does.
+
+Packed PowerShell executables therefore have a habit of making antivirus software very excited, regardless of what is actually inside them. Shipping one would mostly result in me asking people to click past a virus warning. Great first impression.
+
+So this comes as a plain PowerShell script instead. Open it in any text editor and you can see what it does.
+
+The `.bat` is one line. It only starts the script sitting next to it.
 
 ---
 
 ### Linux / Proton
 
-**Linux port status:** This is an experimental Linux/Python port of the Windows/PowerShell v1.3 release. Development and testing of the Python port were carried out by GREYBE4RD, with assistance from ChatGPT, on Arch Linux with SwayWM (Wayland), SteamVR, and an AMD Radeon RX 9070 XT. While the port should be largely distro and hardware-agnostic, behaviour on other distributions, desktop environments, hardware configurations, and VR setups may vary.
+**Linux port status:** experimental.
 
-1. Download the two files: `Linux-HitmanVRFoveationFix-v1.3.py` and `launch.linux.HitmanVRFoveationFix-v1.3.sh`
-   — keep them in the same folder
+This is a Linux/Python port of the Windows/PowerShell **v1.3** release.
+
+Development and testing were done by **GREYBE4RD**, with assistance from ChatGPT, on:
+
+- Arch Linux
+- SwayWM / Wayland
+- SteamVR
+- AMD Radeon RX 9070 XT
+
+Nothing in the port is supposed to depend specifically on that distro or GPU, but it has not been tested across every Linux distribution, desktop environment, graphics card and VR setup in existence. Expect some variation.
+
+1. Download `Linux-HitmanVRFoveationFix-v1.3.py` and `launch.linux.HitmanVRFoveationFix-v1.3.sh`
+   — keep both files in the same folder
 2. Make the launcher executable:
 
    ```bash
    chmod +x launch.linux.HitmanVRFoveationFix-v1.3.sh
    ```
 
-3. Run the launcher:
+3. Run it:
 
    ```bash
    ./launch.linux.HitmanVRFoveationFix-v1.3.sh
    ```
 
-4. Enter your `sudo` password when prompted
+4. Enter your `sudo` password when asked
 5. Start HITMAN however you normally do, including straight into VR
 6. Play
 
-Leave the terminal open while you play. Press `Ctrl+C` to stop the fix and restore any live changes.
+Leave the terminal open while you play.
 
-On Linux, the same states are reported in the terminal.
+Press `Ctrl+C` to stop the fix and restore any live changes.
 
-> Linux/Proton/SteamVR: v1.3 replaces the timing-sensitive v1.2 reload logic and has been visually verified in the headset across new missions, mission restarts, and save-game loads. The Linux port uses the same v1.3 patches and renderer values, with Linux process-memory access in place of the Windows APIs. A Linux-specific 1 ms guard monitors the renderer scale and mask values because Proton can restore them during save-game loads faster than the normal 15 ms lifecycle loop can catch. The guard uses the same validated render-value routine as the main loop, shares the same synchronization and rollback handling, and feeds its writes into the existing v1.3 reload lifecycle.
+The Linux version reports the same states in the terminal.
 
-The Linux launcher serves the same purpose: it changes to the folder containing the script and starts `Linux-HitmanVRFoveationFix-v1.3.py` with the privileges required to access HITMAN's process memory.
+> Linux/Proton/SteamVR: v1.3 replaces the timing-sensitive v1.2 reload logic and has been visually tested in the headset across new missions, mission restarts and save-game loads. It uses the same v1.3 patches and renderer values as the Windows version, with Linux process-memory access replacing the Windows APIs.
+>
+> Proton can restore the renderer scale and mask values during a save-game load faster than the normal 15 ms lifecycle loop can catch them, so the Linux port also runs a 1 ms guard. That guard uses the same validated render-value routine, synchronization and rollback handling as the main loop, and any writes still go through the existing v1.3 reload lifecycle.
+
+The launcher itself is deliberately boring. It changes to the script's folder and starts `Linux-HitmanVRFoveationFix-v1.3.py` with the privileges needed to access HITMAN's process memory.
 
 ---
 
 ## What it actually does
 
-HITMAN renders VR with **fixed foveation**: four layers per frame instead of two.
+HITMAN renders VR using **fixed foveation**.
 
-- Two **wide** layers at half resolution, covering the whole field of view
-- Two **narrow** layers at full resolution, covering only a small circle in the centre
+Instead of rendering one full-resolution image for each eye, it renders four layers per frame:
 
-Everything outside that circle is upscaled from the half-resolution layer. On a
-headset sharp enough to show the difference, the result is a small sharp island in a
-sea of mush — and because the circle is fixed to the centre of the image and not to
-where you are looking, you spend most of your time looking at the blurry part.
+- two **wide** layers at half resolution, covering the whole field of view
+- two **narrow** layers at full resolution, covering only a small circle in the centre
 
-This tool switches the game to **two layers at full resolution**, covering the whole
-field of view. There is no wide/narrow split left at all.
+Outside that circle, the image comes from the half-resolution layer and gets scaled up.
 
-It costs **twice the pixel work**: before, four slices at 936 x 1008 each; after,
-two at 1872 x 2016. Same total field of view, twice the pixels. In testing the frame
-rate held up because the game is not GPU-bound at these resolutions, but that is a
-happy accident, not a free lunch.
+On a headset sharp enough to show it, the result is basically a small sharp island surrounded by blur.
 
-The number that does hold up is the pixel density:
+And the sharp circle does not follow your eyes. It stays fixed in the middle of the image.
+
+Move your eyes away from the centre and you are looking at the blurry part.
+
+This tool changes that to **two full-resolution layers covering the entire field of view**.
+
+The wide/narrow split is gone.
+
+There is one complication.
+
+HITMAN still expects four logical views for geometry and visibility. v1.4 keeps that four-view behaviour, as v1.3 did, but limits the refraction-depth copy to the two physical eye views.
+
+That stops the narrow foveal views leaking into transparent materials without bringing back the geometry pop-in.
+
+### What does it cost?
+
+About **twice the pixel work**.
+
+Before:
+
+- four slices at 936 × 1008
+
+After:
+
+- two slices at 1872 × 2016
+
+The field of view is the same. The renderer is pushing roughly twice as many pixels.
+
+In my testing the frame rate held up because the game was not GPU-bound at these resolutions.
+
+That does **not** mean the extra pixels are free. It just means my test setup had enough GPU headroom to get away with it.
+
+The useful comparison is pixel density:
 
 | | pixels | across | density |
 |---|---|---|---|
 | old sweet spot | 936 | ~49° | 19.1 px/° |
 | now, everywhere | 1872 | 99° | 18.9 px/° |
 
-About one percent apart. You get the old sweet-spot density — you just get it across
-the whole view instead of a small circle in the middle.
+That is about one percent apart.
+
+So the old sharp centre already had basically the right pixel density. The problem was that HITMAN only gave it to a small circle in front of you.
+
+Now you get roughly that density across the whole view.
 
 No resolution setting is changed. You do not need to raise anything.
 
 ---
 
-## Is it safe
+## Is it safe?
 
-- **No game file or setting is modified.** Renderer changes are made in the memory
-  of the running process and disappear when you close HITMAN. The tool keeps a small
-  `foveationfix.log` beside the script so timing problems can be diagnosed; it contains
-  timestamps and renderer state changes and can be deleted at any time.
-- It refuses to do anything if the game code is not in its original state, if VR is
-  already running when it attaches, or if the VR device does not look the way it
-  expects.
-- Turning it off or closing the window restores the bytes owned by that tool
-  instance when they are still safe to touch. Closing HITMAN itself always discards
-  every in-memory change.
+There are two different questions hiding in that word.
 
-**Said plainly:** it does write to the memory of a game that has an online connection.
-That has been fine in testing, but you should know it before you decide. There is no
-way to change what the renderer does without touching the renderer.
+### Does it modify the game permanently?
 
-Verified on build **3.270.1**. On other builds the tool locates the relevant code by
-byte pattern and tells you the build is untested — and if anything is ambiguous, it
-refuses instead of guessing.
+No.
+
+- **No game file or setting is modified.**
+- Renderer changes are made only in the memory of the running HITMAN process.
+- Close HITMAN and the operating system throws that process memory away.
+- The tool writes a small `foveationfix.log` next to the script containing timestamps and renderer state changes. You can delete it whenever you like.
+
+The tool also refuses to continue if:
+
+- the game code is not in the state it expects
+- VR is already running when it attaches
+- the VR device does not look the way it expects
+
+When you stop the tool, it restores the bytes owned by that instance when they are still safe to touch.
+
+v1.4 briefly pauses HITMAN's threads, checks that none of them is currently inside a replaced call block or wrapper, restores the outer refraction hook first, then restores the remaining owned bytes.
+
+Closing HITMAN itself always removes every in-memory change anyway.
+
+### Is there zero risk?
+
+No, and I am not going to pretend there is.
+
+**This tool writes to the memory of a game that has an online connection.**
+
+That has been fine in testing. You should still know it before deciding whether you want to run it.
+
+There is no magic renderer checkbox hidden in an `.ini` file here. Changing what this renderer does means changing the renderer while the game is running.
+
+The fix was verified on build **3.270.1**.
+
+On other builds, the tool searches for both the v1.3 base sites and all three v1.4 refraction call blocks using strong byte patterns.
+
+Both inner calls must resolve to the same `CopyRefractionDepth` target.
+
+If something is missing, ambiguous or inconsistent, the tool stops.
+
+It does not guess.
 
 ---
 
 ## To IO Interactive
 
-If anyone at IOI reads this: you are welcome to take this. No permission needed, no
-credit needed, no strings. The whole change is five instructions and three values,
-all documented in [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md).
+If anyone at IOI reads this: please take it.
 
-Two full-resolution layers instead of four half-resolution ones costs twice the
-pixel work and looks dramatically better on modern headsets — and on hardware that
-is not GPU-bound, which is most of it, that cost does not show. It would be a lovely
-patch note.
+No permission needed. No credit needed. No strings attached.
+
+The original sharpness fix is five instructions and three values.
+
+v1.4 adds two things:
+
+- `CopyRefractionDepth` is limited to the physical eye count
+- the two renderer values which can be restored during loading are continuously watched and repaired
+
+The details are in [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md).
+
+Two full-resolution layers instead of four half-resolution ones means roughly twice the pixel work, but it also looks dramatically better on modern headsets.
+
+On the hardware I tested, there was enough GPU headroom that the extra work did not hurt the frame rate.
+
+It would make a very nice patch note.
 
 ---
 
 ## Reporting a problem
 
-If the tool does not go green, or something looks wrong, please
-[open an issue](https://github.com/RealChrizzl/hitman-vr-foveation-fix/issues) — and
-include **the exact wording the window showed you**. Grey, amber and red all say
-something different, and the message alone usually identifies the cause.
+If the tool does not turn green, or something looks wrong, please
+[open an issue](https://github.com/RealChrizzl/hitman-vr-foveation-fix/issues).
 
-For anything beyond that there is a read-only diagnostic in
-[`tools/`](tools/). Put `HitmanVRProbe.ps1` and `HitmanVRProbe.bat` in the same
-folder, start the game, get into VR and into a mission, double-click the `.bat` and
-press **Copy report**. Probe v1.1 also reports whether every live code site is
-stock, fixed, or unexpected; a foveation value of zero is now displayed correctly.
+Include **the exact wording shown in the window**.
 
-It imports only `OpenProcess`, `ReadProcessMemory` and `CloseHandle` — no write
-function is declared at all, so it cannot modify the game even in principle.
+Grey, amber and red mean different things, and the message usually tells me where things went wrong.
+
+If that is not enough, there is a read-only diagnostic tool in [`tools/`](tools/).
+
+Put `HitmanVRProbe.ps1` and `HitmanVRProbe.bat` in the same folder, start HITMAN, enter VR and load into a mission. Then double-click the `.bat` and press **Copy report**.
+
+Probe v1.1 also reports whether every live v1.3 base-code site is:
+
+- stock
+- fixed
+- unexpected
+
+A foveation value of zero is displayed correctly.
+
+The v1.4 refraction wrappers also monitor their own owner/count telemetry in the main tool and write a compact summary to `foveationfix.log`.
+
+The probe imports only:
+
+- `OpenProcess`
+- `ReadProcessMemory`
+- `CloseHandle`
+
+There is no write function in it at all.
+
+So the probe cannot modify the game even in principle.
 
 ---
 
 ## For the curious
 
-- [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md) — how the foveation works, what the
-  fix changes, and how it was found
-- [`docs/UPDATING.md`](docs/UPDATING.md) — how to re-find everything if a future game
-  update breaks the pattern search
+- [`docs/HOW-IT-WORKS.md`](docs/HOW-IT-WORKS.md) — how HITMAN's foveation works, what the fix changes and how I found it
+- [`docs/UPDATING.md`](docs/UPDATING.md) — how to find everything again if a future game update breaks the pattern search
 
-You do not need either of these to use the tool.
+You do not need either document to use the tool.
+
+They are there for people who see "process memory patching" and immediately want to know exactly which bytes are getting bullied.
 
 ---
 
@@ -195,10 +309,11 @@ You do not need either of these to use the tool.
 
 Made by **RealChrizzl**.
 
-This is the result of roughly twenty hours of reverse engineering, and it would not
-exist without the AI assistants that did the heavy lifting on the disassembly:
-**Claude Opus 5** and **Sol 5.6**. I ran the tests, wore the headset and made the
-calls about what looked right — that part is not something a model can do for you.
+This took roughly twenty hours of reverse engineering.
+
+A large part of the disassembly work was done with **Claude Opus 5** and **Sol 5.6**. I ran the tests, wore the headset and made the calls about what actually looked right.
+
+A model cannot put on a Quest 3 and tell me whether the glass is broken in the left eye.
 
 To be bloody honest: without AI I would not be here sharing software.
 
@@ -206,5 +321,10 @@ To be bloody honest: without AI I would not be here sharing software.
 
 ## Licence
 
-MIT — see [`LICENSE`](LICENSE). Do what you like with it, including forking it if I
-ever stop maintaining it. That is rather the point.
+MIT — see [`LICENSE`](LICENSE).
+
+Do what you like with it.
+
+Fork it if I disappear one day.
+
+That is rather the point.

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -81,17 +81,26 @@ the same machine.
 
 OpenVR rebuilds the render state during mission, scene, and save-game loads. These
 fields must therefore be neutralised before that state reaches transition 3, not
-merely after a new texture pointer appears. v1.3 watches the transition at 15 ms,
-writes as soon as the device geometry is plausible (including before `active=1`),
-reads the values back, and requires multiple samples plus a 250 ms monotonic stable
-window before showing green. A write first observed after transition 3 remains amber
-and asks for one real reload.
+merely after a new texture pointer appears. The normal lifecycle still watches the
+transition at 15 ms, writes as soon as the device geometry is plausible (including
+before `active=1`), reads the values back, and requires multiple samples plus a
+250 ms monotonic stable window before showing green.
+
+Windows v1.4 also starts a separate sleeping guard after the first successful
+`Initialized && Fixed` renderer transaction. Its one-millisecond fast path reads only
+`device+0x490` (16 bytes) and `device+0x4C0` (8 bytes). Matching values cause no
+write and no UI work. A mismatch posts one callback to the WinForms thread and that
+callback reuses the complete validation, ownership, write, verification and rollback
+routine above. The 15 ms timer and callback therefore cannot write concurrently.
+
+If that guard transaction writes while transition 3 is visible, v1.4 records the
+fact in a separate latch. The latch survives a later 15 ms sample of transition 1 or
+2 and is cleared only after the newly observed load cycle reaches transition 3. This
+closes the save-load window without turning the whole UI/lifecycle timer into a
+one-millisecond busy loop.
 
 This lifecycle has been visually verified in the headset across new missions,
-mission restarts, save-game loads, scene changes and Freelancer mode. Polling is
-still not the same as synchronising with the render thread; if a future game build
-reintroduces a fast-load race, the next step is to re-derive and patch the scale/mask
-producer or constant-buffer builder from that build's binary.
+mission restarts, save-game loads, scene changes and Freelancer mode.
 
 Stock values for reference: `+0x490…` = `3EDF2BF0 3ECE8B44 4012D426 401EA625`,
 `+0x4C0/+0x4C4` = `3D 2D 66 3F  DA B9 4D 3E`.
@@ -124,13 +133,55 @@ A **count**, pushed onto a stack in the render context: 1 without VR, 2 with WNO
 4 with WNO on. Whatever consumes it does not cope with 2. Force it to 4 and the
 geometry stays put.
 
-This is safe even though only two views exist, because the central view-matrix
-accessor at `0x1306EFC` masks every requested index with `& 1` when WNO is off — a
-request for view 2 returns view 0. The fallback was already in the code.
+This is correct for geometry even though only two physical eye views exist: the
+central view-matrix accessor at `0x1306EFC` masks requested indices with `& 1` when
+WNO is off, so view 2 maps to eye 0 and view 3 maps to eye 1. v1.4 documents and
+handles the important exception: `CopyRefractionDepth` consumes the numeric context
+count through a fullscreen instance multiplier and therefore must see 2, not 4.
 
 ---
 
-## 4. How it was found
+## 4. Why glass and water need two physical views
+
+v1.3 deliberately keeps the render-context count at four because geometry and
+visibility break at two. Most of the renderer can map logical views 2 and 3 back to
+physical eyes 0 and 1, but the refraction-depth copy multiplies its fullscreen draw
+range by the current context count. That caused the narrow foveal views to leak into
+glass, flowing water, bottles and some emissive/light materials.
+
+v1.4 leaves the outer `DrawRefractiveAndTransparent` pass at four. A small owner
+scope identifies that exact pass, and only its two direct calls to
+`CopyRefractionDepth` temporarily replace the current count 4 with 2. Each wrapper
+restores 4 before returning. The changed call blocks on build 3.270.1 are:
+
+| Address | Role |
+|---|---|
+| `0x011B892A` | owner scope around `DrawRefractiveAndTransparent` |
+| `0x01290BA2` | first `CopyRefractionDepth` call, local 4 -> 2 -> 4 |
+| `0x01291386` | second `CopyRefractionDepth` call, local 4 -> 2 -> 4 |
+
+The wrappers gate on thread ID, render-context pointer and the expected current count.
+Their counters are monitored by the normal 15 ms loop. Installation and live removal
+suspend the game threads, reject any thread whose instruction pointer lies in a
+changed block or wrapper, and publish inner calls before the outer owner gate. Removal
+uses the reverse order.
+
+This exact split was selected by the Test W result: stereo glass and water became
+correct, the simultaneous pop-in disappeared, affected lights became stable, and no
+new global image problem was observed across the reported scenes.
+
+Implementation note: these are private executable wrappers allocated by the external
+PowerShell tool. They use normal Windows x64 calling convention and balanced
+CALL/RET control flow, but an external tool cannot register process-local dynamic
+unwind metadata without executing a registration call inside HITMAN. The normal path
+has been exercised extensively; an actual exception unwinding out of one of the
+wrapped render functions remains a rare release limitation. The cave is never freed
+while the process is alive, and live removal is allowed only after active counters and
+all suspended thread instruction pointers prove it is quiescent.
+
+---
+
+## 5. How it was found
 
 Six hypotheses were tested and all six were wrong: the skipped halving of the render
 target, the Hi-Z buffer (which turned out to belong to screen-space reflections, not

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -94,6 +94,42 @@ Two things are read out of this match rather than assumed:
 
 ## If a pattern no longer matches
 
+### v1.4 refraction call patterns
+
+v1.4 adds three strong patterns. The five-byte `E8` displacement is wildcarded,
+decoded, and range-checked. The two inner patterns must resolve to the same target.
+
+Outer owner scope, hit offset 0, replaced length 18:
+
+```
+48 8B 8C 24 C0 00 00 00 48 89 44 24 20 E8 ?? ?? ?? ??
+48 8D 8C 24 60 02 00 00
+```
+
+First `CopyRefractionDepth` call, hit offset 18, replaced length 21:
+
+```
+48 8B 8D B0 01 00 00 48 8D 95 D0 01 00 00 89 44 24 28
+4D 8B C4 8B 41 04 44 8B 09 48 8B CE 89 44 24 20 E8 ?? ?? ?? ??
+48 8B 9D D0 01 00 00 48 8B F8 48 8B 0D ?? ?? ?? ??
+4C 8D 0D ?? ?? ?? ??
+```
+
+Second call, also hit offset 18 and length 21:
+
+```
+48 8B 8D B0 01 00 00 48 8D 95 D0 01 00 00 89 44 24 28
+4D 8B C4 8B 41 04 44 8B 09 48 8B CE 89 44 24 20 E8 ?? ?? ?? ??
+48 8B 9D D0 01 00 00 48 8B F8 48 8B 85 B0 01 00 00
+4C 8B 40 60 4D 85 C0
+```
+
+Do not patch the shared fullscreen helper globally. The outer wrapper is an owner
+marker only; it does not change the context count. Each inner wrapper changes the
+current slot from 4 to 2 only for its direct call, then verifies and restores 4.
+
+---
+
 Work from what the code *does*, not from where it was.
 
 **Writers A and B** are the only places that store to `device+WNO`. Find every
@@ -124,12 +160,16 @@ have to be re-derived from the builder function.
 
 ## Verifying a change
 
-There is no substitute for putting the headset on. Two checks that matter:
+There is no substitute for putting the headset on. Three checks that matter:
 
 1. **Sharpness** — the whole field of view should look like the centre used to. The
    status window should show two layers at the full per-eye size, not half.
 2. **Geometry** — stand somewhere busy and move your head *and your position*. Nothing
    should pop in and out. If it does, the view count patch is not taking effect.
+3. **Transparency and refraction** — check glass panes, NPC glasses, flowing water,
+   bottles, emissive lights and at least one large panorama window while turning and
+   leaning your head. Both eyes must agree, and affected objects must not pop in both
+   eyes together or switch brightness with head angle.
 
-The second check is the one that is easy to skip and expensive to get wrong. It is
-what took the longest to find in the first place.
+The second and third checks are easy to skip and expensive to get wrong. They are
+what took the longest to isolate in the first place.


### PR DESCRIPTION
## Summary

- fix stereo mismatches in glass, flowing water, bottles, emissive materials, and affected lights
- keep geometry/visibility on four logical views while limiting the two CopyRefractionDepth calls to two physical eye views
- add a separate sleeping ~1 ms renderer guard for save-load scale/mask races while preserving the 15 ms UI/lifecycle loop
- update the Windows documentation and keep the merged Linux/Proton port intact

## Validation

- full v1.4 QA: 81 assertions passed against the verified HITMAN 3.270.1 executable and the slim release archive
- in-headset validation covered villa panes, NPC glasses, flowing water, lights, panorama glass, and aquarium scenes
- release ZIP contains only the launcher, PowerShell script, README, LICENSE, and v1.4 changelog
